### PR TITLE
feat(claude_code): pre-configure all plugins for auto-activation

### DIFF
--- a/roles/claude_code/files/plugins/known_marketplaces.json
+++ b/roles/claude_code/files/plugins/known_marketplaces.json
@@ -1,0 +1,14 @@
+{
+  "claude-plugins-official": {
+    "source": {
+      "source": "github",
+      "repo": "anthropics/claude-plugins-official"
+    }
+  },
+  "caveman": {
+    "source": {
+      "source": "github",
+      "repo": "JuliusBrussee/caveman"
+    }
+  }
+}

--- a/roles/claude_code/files/settings.json
+++ b/roles/claude_code/files/settings.json
@@ -2,5 +2,20 @@
   "effortLevel": "max",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "enabledPlugins": {
+    "ralph-loop@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "session-report@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "claude-md-management@claude-plugins-official": true,
+    "hookify@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "github@claude-plugins-official": true,
+    "terraform@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "telegram@claude-plugins-official": true,
+    "caveman@caveman": true
   }
 }

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -186,6 +186,28 @@
     mode: '0644'
   when: claude_config_mode | default('link') == 'copy'
 
+# ── Plugin config (marketplaces pre-registered, plugins enabled via settings.json)
+- name: Ensure ~/.claude/plugins directory exists
+  ansible.builtin.file:
+    path: "{{ claude_home }}/.claude/plugins"
+    state: directory
+    mode: '0755'
+
+- name: Deploy known_marketplaces.json (link)
+  ansible.builtin.file:
+    src: "{{ role_path }}/files/plugins/known_marketplaces.json"
+    dest: "{{ claude_home }}/.claude/plugins/known_marketplaces.json"
+    state: link
+    force: yes
+  when: claude_config_mode | default('link') == 'link'
+
+- name: Deploy known_marketplaces.json (copy)
+  ansible.builtin.copy:
+    src: plugins/known_marketplaces.json
+    dest: "{{ claude_home }}/.claude/plugins/known_marketplaces.json"
+    mode: '0644'
+  when: claude_config_mode | default('link') == 'copy'
+
 # ── Install script ──────────────────────────────────────────────────────────
 - name: Copy Claude Code install script
   ansible.builtin.copy:


### PR DESCRIPTION
Plugins enabled in settings.json + marketplaces pre-registered. Zero manual setup.