### PR TITLE
feat(claude_code): MCP server framework + SonarQube

### DIFF
--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -14,7 +14,6 @@ claude_config_mode: link
 claude_home: "{{ '/home/' + host_username if host_username is defined else ansible_facts['env']['HOME'] }}"
 
 # ── Marketplace plugins (installed via `claude plugin install <name>`) ──────
-# Official Anthropic marketplace (claude-plugins-official)
 claude_plugins:
   - ralph-loop
   - code-review
@@ -32,7 +31,7 @@ claude_external_plugins:
   - playwright
   - telegram
 
-# Third-party marketplaces to add before installing their plugins
+# Third-party marketplaces
 claude_custom_marketplaces:
   - JuliusBrussee/caveman
 
@@ -41,8 +40,14 @@ claude_custom_plugins:
   - caveman@caveman
 
 # ── npm packages (installed globally via `npm install -g`) ─────────────────
+# For npx-based skills/tools and MCP servers
 claude_npm_packages:
   - impeccable
+  - sonarqube-mcp-server
+
+# ── MCP servers (merged into ~/.claude.json from files/mcp/*.json) ─────────
+# Drop .json files in files/mcp/ to add servers. See files/mcp/README.md.
+deploy_mcp_servers: true
 
 # ── Local skills (deployed from files/skills/<name>/SKILL.md) ──────────────
 deploy_skills: true

--- a/roles/claude_code/files/mcp/README.md
+++ b/roles/claude_code/files/mcp/README.md
@@ -1,0 +1,39 @@
+# MCP Server Definitions
+
+Drop JSON files here to add MCP servers to your Claude Code configuration.
+Each file defines one or more MCP servers that get merged into `~/.claude.json`.
+
+## File Format
+
+Each `.json` file should contain an object with MCP server definitions:
+
+```json
+{
+  "server-name": {
+    "command": "npx",
+    "args": ["-y", "package-name@latest"],
+    "env": {
+      "API_KEY": "${ENV_VAR_NAME}"
+    }
+  }
+}
+```
+
+## Environment Variables
+
+Use `${VAR_NAME}` syntax for secrets. Set them in your shell profile or `.env` file.
+Never hardcode tokens or API keys in these files.
+
+## Adding a New MCP Server
+
+1. Create `<server-name>.json` in this directory
+2. Run the Ansible playbook (or `make dev` to rebuild the container)
+3. The server will be available in your next Claude Code session
+
+## Removing an MCP Server
+
+Delete the `.json` file and re-run the playbook.
+
+## Currently Configured
+
+- `sonarqube.json` — SonarCloud/SonarQube code analysis (requires SONARQUBE_TOKEN)

--- a/roles/claude_code/files/mcp/sonarqube.json
+++ b/roles/claude_code/files/mcp/sonarqube.json
@@ -1,0 +1,11 @@
+{
+  "sonarqube": {
+    "command": "npx",
+    "args": ["-y", "sonarqube-mcp-server@latest"],
+    "env": {
+      "SONARQUBE_URL": "https://sonarcloud.io",
+      "SONARQUBE_TOKEN": "${SONARQUBE_TOKEN}",
+      "SONARQUBE_ORGANIZATION": "${SONARQUBE_ORGANIZATION}"
+    }
+  }
+}

--- a/roles/claude_code/files/settings.json
+++ b/roles/claude_code/files/settings.json
@@ -17,5 +17,16 @@
     "playwright@claude-plugins-official": true,
     "telegram@claude-plugins-official": true,
     "caveman@caveman": true
+  },
+  "mcpServers": {
+    "sonarqube": {
+      "command": "npx",
+      "args": ["-y", "sonarqube-mcp-server@latest"],
+      "env": {
+        "SONARQUBE_URL": "https://sonarcloud.io",
+        "SONARQUBE_TOKEN": "${SONARQUBE_TOKEN}",
+        "SONARQUBE_ORGANIZATION": "${SONARQUBE_ORGANIZATION}"
+      }
+    }
   }
 }

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -208,6 +208,47 @@
     mode: '0644'
   when: claude_config_mode | default('link') == 'copy'
 
+# ── MCP servers (merged into ~/.claude.json) ────────────────────────────────
+# Each .json file in files/mcp/ defines MCP servers. They get merged into
+# the mcpServers key of ~/.claude.json (the global Claude config).
+- name: Find MCP server definition files
+  ansible.builtin.find:
+    paths: "{{ role_path }}/files/mcp"
+    patterns: "*.json"
+  register: mcp_files
+
+- name: Merge MCP server definitions into ~/.claude.json
+  ansible.builtin.script:
+    cmd: python3 -c "
+import json, glob, os
+
+claude_json_path = '{{ claude_home }}/.claude.json'
+mcp_dir = '{{ role_path }}/files/mcp'
+
+# Read existing ~/.claude.json or create empty
+if os.path.exists(claude_json_path):
+    with open(claude_json_path) as f:
+        config = json.load(f)
+else:
+    config = {}
+
+# Ensure mcpServers key exists
+if 'mcpServers' not in config:
+    config['mcpServers'] = {}
+
+# Merge each .json file from mcp/
+for mcp_file in glob.glob(os.path.join(mcp_dir, '*.json')):
+    with open(mcp_file) as f:
+        servers = json.load(f)
+    config['mcpServers'].update(servers)
+
+with open(claude_json_path, 'w') as f:
+    json.dump(config, f, indent=2)
+
+print(f'Merged {len(glob.glob(os.path.join(mcp_dir, \"*.json\")))} MCP server files')
+"
+  when: mcp_files.matched > 0
+
 # ── Install script ──────────────────────────────────────────────────────────
 - name: Copy Claude Code install script
   ansible.builtin.copy:


### PR DESCRIPTION
Drop .json files in roles/claude_code/files/mcp/ to add MCP servers. Ansible merges them into ~/.claude.json. Includes SonarQube/SonarCloud MCP pre-configured.