### PR TITLE
feat(claude_code): pin effortLevel=max with self-healing SessionStart hook

### DIFF
--- a/files/claude-code/CLAUDE.md
+++ b/files/claude-code/CLAUDE.md
@@ -17,3 +17,10 @@ Agent teams are enabled. Use `claude --agent orchestrator` to start a continuous
 - One concern per commit, format: `type(scope): description`
 - Always read AGENTS.md and AI_INSTRUCTIONS.md in the project repo first
 - Prefer worktree isolation for implementation work
+
+## Effort level
+
+`effortLevel` is pinned to `max` in `~/.claude/settings.json` and self-heals
+on every session start via `~/.claude/hooks/preserve-effort-max.sh`. Do not
+override with `--effort low|medium|high` unless you genuinely need to throttle
+a one-off run.

--- a/files/claude-code/install.sh
+++ b/files/claude-code/install.sh
@@ -73,11 +73,22 @@ echo "Target   : $CLAUDE_DIR"
 echo ""
 
 # ── Create target directory ───────────────────────────────────────────────────
-mkdir -p "$CLAUDE_DIR/agents"
+mkdir -p "$CLAUDE_DIR/agents" "$CLAUDE_DIR/hooks"
 
 # ── Symlink core config files ─────────────────────────────────────────────────
 ln -sf "$SCRIPT_DIR/settings.json" "$CLAUDE_DIR/settings.json"
 echo "  linked  settings.json       → $SCRIPT_DIR/settings.json"
+
+# Hook scripts (referenced from settings.json `hooks` block).
+# Mirrors what roles/claude_code/tasks/main.yml does in the Ansible flow.
+HOOK_SRC="$(cd "$SCRIPT_DIR/../../roles/claude_code/files/hooks" 2>/dev/null && pwd || true)"
+if [ -n "$HOOK_SRC" ]; then
+  for h in "$HOOK_SRC/"*.sh; do
+    [ -f "$h" ] || continue
+    ln -sf "$h" "$CLAUDE_DIR/hooks/$(basename "$h")"
+    echo "  linked  hooks/$(basename "$h") → $h"
+  done
+fi
 
 ln -sf "$SCRIPT_DIR/CLAUDE.md" "$CLAUDE_DIR/CLAUDE.md"
 echo "  linked  CLAUDE.md           → $SCRIPT_DIR/CLAUDE.md"

--- a/files/claude-code/settings.json
+++ b/files/claude-code/settings.json
@@ -2,5 +2,18 @@
   "effortLevel": "max",
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/preserve-effort-max.sh\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
   }
 }

--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -16,3 +16,10 @@ Agent teams are enabled. Use `claude --agent orchestrator` to start a continuous
 - One concern per commit, format: `type(scope): description`
 - Always read AGENTS.md and AI_INSTRUCTIONS.md in the project repo first
 - Prefer worktree isolation for implementation work
+
+## Effort level
+
+`effortLevel` is pinned to `max` in `~/.claude/settings.json` and self-heals
+on every session start via `~/.claude/hooks/preserve-effort-max.sh`. Do not
+override with `--effort low|medium|high` unless you genuinely need to throttle
+a one-off run.

--- a/roles/claude_code/files/hooks/README.md
+++ b/roles/claude_code/files/hooks/README.md
@@ -1,0 +1,42 @@
+# Claude Code hooks
+
+Shell scripts deployed to `~/.claude/hooks/` and invoked from the `hooks` block
+in `~/.claude/settings.json`.
+
+## `preserve-effort-max.sh`
+
+Keeps `effortLevel: max` pinned in `~/.claude/settings.json`.
+
+### Why
+
+The Claude CLI rewrites `~/.claude/settings.json` whenever the user toggles
+plugins, edits permissions, or accepts a security prompt. Historically these
+rewrites have dropped the `effortLevel` key (per the Anthropic changelog:
+*"Fixed `--effort` CLI flag being reset by unrelated settings writes on
+startup"*). This hook self-heals after such rewrites.
+
+### Behaviour
+
+| Starting state of `~/.claude/settings.json` | Result |
+|---|---|
+| File missing | Created with `{"effortLevel":"max"}` |
+| Key missing | Key added, other keys preserved |
+| `effortLevel` set to anything other than `max` | Reset to `max` |
+| `effortLevel` already `max` | No-op (mtime preserved — idempotent) |
+| File contains malformed JSON | Hook exits 0 silently — never clobbers user data |
+
+The hook never blocks session start: it always exits 0, even on failure. The
+worst case is that the user sees the same broken state they already had.
+
+### Wiring
+
+`roles/claude_code/files/settings.json` registers the hook under
+`hooks.SessionStart`. The Ansible role (`roles/claude_code/tasks/main.yml`)
+deploys every `*.sh` in this directory to `~/.claude/hooks/` — symlinked
+in `link` mode, copied (mode 0755) in `copy` mode (Docker).
+
+### Manual test
+
+```bash
+./tests/test-effort-max.sh
+```

--- a/roles/claude_code/files/hooks/preserve-effort-max.sh
+++ b/roles/claude_code/files/hooks/preserve-effort-max.sh
@@ -29,7 +29,7 @@ command -v python3 >/dev/null 2>&1 || exit 0
 
 mkdir -p "$(dirname "$SETTINGS")" 2>/dev/null || exit 0
 
-python3 - "$SETTINGS" <<'PY'
+python3 - "$SETTINGS" <<'PY' || true
 import json, os, sys
 
 path = sys.argv[1]
@@ -54,10 +54,20 @@ if data.get("effortLevel") == target:
 
 data["effortLevel"] = target
 
-# Atomic write via tmp + rename to avoid a partial file if interrupted.
-tmp = path + ".tmp"
-with open(tmp, "w") as fp:
-    json.dump(data, fp, indent=2)
-    fp.write("\n")
-os.replace(tmp, path)
+# Atomic write via tmp + rename. Swallow write errors (permission denied, disk
+# full, rename failure) so the hook never blocks session start — the user keeps
+# the same state they already had.
+try:
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fp:
+        json.dump(data, fp, indent=2)
+        fp.write("\n")
+    os.replace(tmp, path)
+except Exception:
+    sys.exit(0)
 PY
+
+# Hooks must never block SessionStart, regardless of the python subprocess's
+# exit code. The `|| true` on the heredoc above plus this explicit exit belt-
+# and-braces that guarantee.
+exit 0

--- a/roles/claude_code/files/hooks/preserve-effort-max.sh
+++ b/roles/claude_code/files/hooks/preserve-effort-max.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# preserve-effort-max.sh — keep Claude Code pinned to "max" effort.
+#
+# Why: ~/.claude/settings.json gets rewritten by the Claude CLI whenever the
+# user toggles plugins, edits permissions, or accepts a security prompt. These
+# rewrites have historically dropped the `effortLevel` key (see Anthropic
+# changelog: "Fixed `--effort` CLI flag being reset by unrelated settings
+# writes on startup"). This hook restores it.
+#
+# Behaviour:
+#   - Missing file               → create with {"effortLevel":"max"}
+#   - Missing key                → add effortLevel: max
+#   - Wrong value                → reset to max
+#   - Already max                → no-op (mtime preserved)
+#   - Malformed JSON             → exit 0 silently (don't clobber user data)
+#
+# Usage:
+#   - Invoked from settings.json `hooks.SessionStart` on every Claude session.
+#   - Safe to run manually:  ~/.claude/hooks/preserve-effort-max.sh
+#
+# Exit code: always 0. Hooks should never block session start; if we can't
+# fix it, the user already has the same broken state they had before.
+set -u
+
+SETTINGS="${HOME}/.claude/settings.json"
+
+# Need python3 — present on every dev box we target. Bail silently if not.
+command -v python3 >/dev/null 2>&1 || exit 0
+
+mkdir -p "$(dirname "$SETTINGS")" 2>/dev/null || exit 0
+
+python3 - "$SETTINGS" <<'PY'
+import json, os, sys
+
+path = sys.argv[1]
+target = "max"
+
+# Load (or seed) settings. If the file is malformed, leave it alone — the user
+# may be mid-edit, and clobbering their JSON would be worse than skipping the
+# repair.
+if os.path.exists(path):
+    try:
+        with open(path, "r") as fp:
+            data = json.load(fp)
+        if not isinstance(data, dict):
+            sys.exit(0)
+    except Exception:
+        sys.exit(0)
+else:
+    data = {}
+
+if data.get("effortLevel") == target:
+    sys.exit(0)  # idempotent — preserve mtime
+
+data["effortLevel"] = target
+
+# Atomic write via tmp + rename to avoid a partial file if interrupted.
+tmp = path + ".tmp"
+with open(tmp, "w") as fp:
+    json.dump(data, fp, indent=2)
+    fp.write("\n")
+os.replace(tmp, path)
+PY

--- a/roles/claude_code/files/settings.json
+++ b/roles/claude_code/files/settings.json
@@ -28,5 +28,18 @@
         "SONARQUBE_ORGANIZATION": "${SONARQUBE_ORGANIZATION}"
       }
     }
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$HOME/.claude/hooks/preserve-effort-max.sh\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ]
   }
 }

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -189,33 +189,35 @@
 # ── Hooks (user-level shell scripts invoked from settings.json hooks block) ──
 # preserve-effort-max.sh keeps effortLevel=max in ~/.claude/settings.json even
 # when the Claude CLI rewrites the file (toggling plugins, accepting prompts).
+#
+# Listing uses `fileglob` (a controller-side lookup) rather than `find` so the
+# task works in `copy` mode against remote/containerised targets — the role
+# files only exist on the controller.
 - name: Ensure ~/.claude/hooks directory exists
   ansible.builtin.file:
     path: "{{ claude_home }}/.claude/hooks"
     state: directory
     mode: '0755'
 
-- name: Find hook scripts in role
-  ansible.builtin.find:
-    paths: "{{ role_path }}/files/hooks"
-    patterns: "*.sh"
-  register: hook_files
+- name: List hook scripts in role (controller-side)
+  ansible.builtin.set_fact:
+    hook_files: "{{ query('fileglob', role_path ~ '/files/hooks/*.sh') }}"
 
 - name: Symlink each hook script into ~/.claude/hooks/
   ansible.builtin.file:
-    src: "{{ item.path }}"
-    dest: "{{ claude_home }}/.claude/hooks/{{ item.path | basename }}"
+    src: "{{ item }}"
+    dest: "{{ claude_home }}/.claude/hooks/{{ item | basename }}"
     state: link
     force: yes
-  loop: "{{ hook_files.files }}"
+  loop: "{{ hook_files }}"
   when: claude_config_mode | default('link') == 'link'
 
 - name: Copy each hook script into ~/.claude/hooks/
   ansible.builtin.copy:
-    src: "{{ item.path }}"
-    dest: "{{ claude_home }}/.claude/hooks/{{ item.path | basename }}"
+    src: "{{ item }}"
+    dest: "{{ claude_home }}/.claude/hooks/{{ item | basename }}"
     mode: '0755'
-  loop: "{{ hook_files.files }}"
+  loop: "{{ hook_files }}"
   when: claude_config_mode | default('link') == 'copy'
 
 # ── Plugin directory (marketplaces created by `claude plugin install`) ───────

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -208,7 +208,7 @@
     src: "{{ item }}"
     dest: "{{ claude_home }}/.claude/hooks/{{ item | basename }}"
     state: link
-    force: yes
+    force: true
   loop: "{{ hook_files }}"
   when: claude_config_mode | default('link') == 'link'
 

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -186,6 +186,38 @@
     mode: '0644'
   when: claude_config_mode | default('link') == 'copy'
 
+# ── Hooks (user-level shell scripts invoked from settings.json hooks block) ──
+# preserve-effort-max.sh keeps effortLevel=max in ~/.claude/settings.json even
+# when the Claude CLI rewrites the file (toggling plugins, accepting prompts).
+- name: Ensure ~/.claude/hooks directory exists
+  ansible.builtin.file:
+    path: "{{ claude_home }}/.claude/hooks"
+    state: directory
+    mode: '0755'
+
+- name: Find hook scripts in role
+  ansible.builtin.find:
+    paths: "{{ role_path }}/files/hooks"
+    patterns: "*.sh"
+  register: hook_files
+
+- name: Symlink each hook script into ~/.claude/hooks/
+  ansible.builtin.file:
+    src: "{{ item.path }}"
+    dest: "{{ claude_home }}/.claude/hooks/{{ item.path | basename }}"
+    state: link
+    force: yes
+  loop: "{{ hook_files.files }}"
+  when: claude_config_mode | default('link') == 'link'
+
+- name: Copy each hook script into ~/.claude/hooks/
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "{{ claude_home }}/.claude/hooks/{{ item.path | basename }}"
+    mode: '0755'
+  loop: "{{ hook_files.files }}"
+  when: claude_config_mode | default('link') == 'copy'
+
 # ── Plugin directory (marketplaces created by `claude plugin install`) ───────
 - name: Ensure ~/.claude/plugins directory exists
   ansible.builtin.file:

--- a/tests/test-effort-max.sh
+++ b/tests/test-effort-max.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Unit test: ensure Claude Code is pinned to "max" effort.
+#
+# Validates two layers of enforcement:
+#   1. Static: both checked-in settings.json files declare effortLevel: max.
+#   2. Runtime: the preserve-effort-max.sh hook is idempotent and self-healing.
+#
+# No Docker / no network. Runs in <1s. Wired into CI via .github/workflows/main.yml.
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROLE_SETTINGS="$REPO_ROOT/roles/claude_code/files/settings.json"
+STANDALONE_SETTINGS="$REPO_ROOT/files/claude-code/settings.json"
+HOOK="$REPO_ROOT/roles/claude_code/files/hooks/preserve-effort-max.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1" >&2; FAIL=$((FAIL + 1)); }
+
+# ── Layer 1: static settings ─────────────────────────────────────────────────
+echo "── Layer 1: static settings ─────────────────────────────────────────"
+for f in "$ROLE_SETTINGS" "$STANDALONE_SETTINGS"; do
+  [ -f "$f" ] || { fail "missing file: $f"; continue; }
+  level=$(python3 -c "import json; print(json.load(open('$f')).get('effortLevel', ''))")
+  if [ "$level" = "max" ]; then
+    pass "$f → effortLevel=max"
+  else
+    fail "$f → effortLevel='$level' (want 'max')"
+  fi
+done
+
+# ── Layer 2: hook script ─────────────────────────────────────────────────────
+echo ""
+echo "── Layer 2: preserve-effort-max.sh hook ────────────────────────────"
+[ -x "$HOOK" ] || fail "hook not executable: $HOOK"
+[ -x "$HOOK" ] && pass "hook is executable"
+
+# Sandbox: scratch HOME with throw-away settings file
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+mkdir -p "$SANDBOX/.claude"
+SANDBOX_SETTINGS="$SANDBOX/.claude/settings.json"
+
+# Case A: missing key → hook adds it
+echo '{"env":{"X":"1"}}' > "$SANDBOX_SETTINGS"
+HOME="$SANDBOX" "$HOOK" >/dev/null 2>&1 || true
+got=$(python3 -c "import json; print(json.load(open('$SANDBOX_SETTINGS')).get('effortLevel'))")
+[ "$got" = "max" ] && pass "case A: adds effortLevel when missing" \
+  || fail "case A: got '$got', expected 'max'"
+
+# Case A.1: hook preserves untouched keys
+got_x=$(python3 -c "import json; print(json.load(open('$SANDBOX_SETTINGS')).get('env',{}).get('X'))")
+[ "$got_x" = "1" ] && pass "case A.1: preserves unrelated keys" \
+  || fail "case A.1: env.X='$got_x', expected '1'"
+
+# Case B: drifted value → hook resets to max
+echo '{"effortLevel":"low","env":{"X":"1"}}' > "$SANDBOX_SETTINGS"
+HOME="$SANDBOX" "$HOOK" >/dev/null 2>&1 || true
+got=$(python3 -c "import json; print(json.load(open('$SANDBOX_SETTINGS')).get('effortLevel'))")
+[ "$got" = "max" ] && pass "case B: resets drifted value to max" \
+  || fail "case B: got '$got', expected 'max'"
+
+# Case C: already max → hook is a no-op (idempotent, no rewrite)
+echo '{"effortLevel":"max","env":{"X":"1"}}' > "$SANDBOX_SETTINGS"
+mtime_before=$(stat -c %Y "$SANDBOX_SETTINGS" 2>/dev/null || stat -f %m "$SANDBOX_SETTINGS")
+sleep 1
+HOME="$SANDBOX" "$HOOK" >/dev/null 2>&1 || true
+mtime_after=$(stat -c %Y "$SANDBOX_SETTINGS" 2>/dev/null || stat -f %m "$SANDBOX_SETTINGS")
+[ "$mtime_before" = "$mtime_after" ] && pass "case C: idempotent (no rewrite when already max)" \
+  || fail "case C: file rewritten unnecessarily (mtime $mtime_before → $mtime_after)"
+
+# Case D: missing settings.json → hook creates it
+rm -f "$SANDBOX_SETTINGS"
+HOME="$SANDBOX" "$HOOK" >/dev/null 2>&1 || true
+[ -f "$SANDBOX_SETTINGS" ] && \
+  got=$(python3 -c "import json; print(json.load(open('$SANDBOX_SETTINGS')).get('effortLevel'))") || got=""
+[ "$got" = "max" ] && pass "case D: creates settings.json when missing" \
+  || fail "case D: file not created or effortLevel='$got'"
+
+# Case E: malformed JSON → hook should NOT clobber (silent no-op + non-fatal)
+echo 'not json {' > "$SANDBOX_SETTINGS"
+HOME="$SANDBOX" "$HOOK" >/dev/null 2>&1
+rc=$?
+content=$(cat "$SANDBOX_SETTINGS")
+[ "$rc" = "0" ] && [ "$content" = "not json {" ] && pass "case E: leaves malformed JSON untouched, exits 0" \
+  || fail "case E: rc=$rc content='$content'"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+echo ""
+echo "── Summary ──────────────────────────────────────────────────────────"
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+[ "$FAIL" = "0" ] || exit 1

--- a/tests/test-effort-max.sh
+++ b/tests/test-effort-max.sh
@@ -5,7 +5,8 @@
 #   1. Static: both checked-in settings.json files declare effortLevel: max.
 #   2. Runtime: the preserve-effort-max.sh hook is idempotent and self-healing.
 #
-# No Docker / no network. Runs in <1s. Wired into CI via .github/workflows/main.yml.
+# No Docker / no network. Runs in ~1s (includes a `sleep 1` to cross the
+# filesystem mtime boundary for the idempotency check). Run manually.
 set -e
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## Why

Live \`~/.claude/settings.json\` keeps losing the \`effortLevel\` key. Per Anthropic changelog: *"Fixed \`--effort\` CLI flag being reset by unrelated settings writes on startup"* — the Claude CLI rewrites the settings file whenever the user toggles plugins, edits permissions, or accepts a security prompt, and historically those rewrites have stripped the key.

Without enforcement, the user has to remember to pass \`--effort max\` on every invocation or re-edit the settings file by hand.

## Summary

- New self-healing hook **\`roles/claude_code/files/hooks/preserve-effort-max.sh\`** restores \`effortLevel: max\` whenever it drifts. Idempotent (no rewrite when already max), atomic (tmp + rename), never clobbers malformed JSON, always exits 0 so it can never block session start.
- Both **\`roles/claude_code/files/settings.json\`** (Ansible) and **\`files/claude-code/settings.json\`** (standalone) register the hook under \`hooks.SessionStart\` with a 3s timeout.
- **\`roles/claude_code/tasks/main.yml\`** deploys every \`*.sh\` in \`files/hooks/\` to \`~/.claude/hooks/\` — symlinks in \`link\` mode, copies (mode 0755) in \`copy\` mode (Docker).
- **\`files/claude-code/install.sh\`** mirrors the same wiring for users who skip Ansible.
- Both CLAUDE.md files gain an "Effort level" section.

## Repair matrix

| Starting state of \`~/.claude/settings.json\` | Result |
|---|---|
| File missing | Created with \`{"effortLevel":"max"}\` |
| Key missing | Key added, other keys preserved |
| \`effortLevel\` set to anything other than \`max\` | Reset to \`max\` |
| \`effortLevel\` already \`max\` | No-op (mtime preserved) |
| Malformed JSON | Hook exits 0 silently — never clobbers user data |

## Test plan

- [x] **Unit**: \`./tests/test-effort-max.sh\` — 9 cases covering both static settings files and all five hook paths above. **9/9 PASS**.
- [x] **JSON validity**: \`python3 -c "import json; json.load(open(...))"\` on both settings files.
- [x] **YAML validity**: \`python3 -c "import yaml; yaml.safe_load(open('roles/claude_code/tasks/main.yml'))"\`.
- [ ] CI step that runs \`tests/test-effort-max.sh\` automatically (deferred — orchestrator gh token lacks \`workflow\` scope; will be added in a follow-up PR).
- [ ] **Manual smoke**: rerun the Ansible role on a host where \`~/.claude/settings.json\` was missing \`effortLevel\`; verify \`~/.claude/hooks/preserve-effort-max.sh\` is deployed and that the next \`claude\` session restores the key.

## Out of scope

- Adding the CI test step needs a token with the \`workflow\` scope (orchestrator OAuth app cannot create or update workflow files). Will be a one-line follow-up: \`- run: ./tests/test-effort-max.sh\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)