### PR TITLE
chore(deps): enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,44 @@
+# Dependabot configuration for automated dependency updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # GitHub Actions workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "04:00"
+    open-pull-requests-limit: 5
+    assignees:
+      - "prashantsolanki3"
+    commit-message:
+      prefix: "ci"
+      prefix-development: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"
+      - "ci-cd"
+
+  # Docker base images used in integration tests
+  - package-ecosystem: "docker"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "04:00"
+    open-pull-requests-limit: 3
+    assignees:
+      - "prashantsolanki3"
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"
+    ignore:
+      # Be conservative with base image major version bumps
+      - dependency-name: "ubuntu"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
Enables Dependabot version updates for GitHub Actions and Docker base images.

## Enabled ecosystems
- `github-actions` — `/` (weekly, Wed 04:00, limit 5)
- `docker` — `/tests` (weekly, Thu 04:00, limit 3; ignores Ubuntu major bumps)

Commits use `ci`/`docker` prefixes with scope; PRs are labelled and auto-assigned to @prashantsolanki3.

No Python, Node, or Terraform manifests were detected, so only the two ecosystems above were configured.