### PR TITLE
fix(roles): bool-filter flag conditionals + align Azure CLI keyring

### DIFF
--- a/.github/workflows/provisioning-test.yml
+++ b/.github/workflows/provisioning-test.yml
@@ -14,7 +14,7 @@ name: Ansible-Provisioning-Test
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - 'roles/**'
       - 'dev.yml'

--- a/.github/workflows/provisioning-test.yml
+++ b/.github/workflows/provisioning-test.yml
@@ -59,36 +59,23 @@ jobs:
           ansible-galaxy role install -r requirements.yml --force
           ansible-galaxy collection install community.general
 
-      - name: Build extra-vars file (typed bools for ansible-core 2.20 strict conditionals)
-        # Passing `-e foo=false` on the CLI coerces the value to the string
-        # "false", which some role `when:` clauses interpret as truthy under
-        # ansible-core 2.20's tightened conditional evaluation. A JSON
-        # extra-vars file preserves booleans as actual booleans.
-        run: |
-          # install_az_cli=false: ubuntu-latest runners ship with Azure CLI
-          # already configured via /etc/apt/keyrings/microsoft.gpg; re-adding
-          # the repo under a different keyring path triggers
-          #   "Conflicting values set for option Signed-By"
-          # from APT. Skipping the install in CI preserves coverage of every
-          # other dev_tools sub-task without masking real role bugs.
-          cat > /tmp/ci-vars.json <<JSON
-          {
-            "host_username": "$(whoami)",
-            "claude_config_mode": "copy",
-            "ssh_enabled": false,
-            "update_system": false,
-            "install_az_cli": false
-          }
-          JSON
-          cat /tmp/ci-vars.json
-
       - name: Run ${{ matrix.playbook }} (first pass — provisioning)
         id: first_run
+        # Flag `when:` clauses in the roles now pipe through `| bool`, so
+        # `-e foo=false` coerces correctly and we no longer need a JSON
+        # extra-vars file to preserve boolean types.
+        # `install_az_cli` defaults to true: the role now writes the key to
+        # /etc/apt/keyrings/microsoft.gpg (same path as the runner's
+        # pre-installed Azure CLI), so APT no longer reports conflicting
+        # signed-by values.
         run: |
           ansible-playbook ${{ matrix.playbook }} \
             -i "localhost," \
             --connection=local \
-            -e "@/tmp/ci-vars.json"
+            -e "host_username=$(whoami)" \
+            -e "claude_config_mode=copy" \
+            -e "ssh_enabled=false" \
+            -e "update_system=false"
 
       - name: Run ${{ matrix.playbook }} (second pass — idempotence check)
         id: second_run
@@ -106,7 +93,10 @@ jobs:
           ansible-playbook ${{ matrix.playbook }} \
             -i "localhost," \
             --connection=local \
-            -e "@/tmp/ci-vars.json" \
+            -e "host_username=$(whoami)" \
+            -e "claude_config_mode=copy" \
+            -e "ssh_enabled=false" \
+            -e "update_system=false" \
             | tee /tmp/second_run.log
 
           CHANGED=$(grep -E '^localhost' /tmp/second_run.log | grep -oE 'changed=[0-9]+' | head -1 | cut -d= -f2)

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -9,7 +9,7 @@
   until: result is not failed
   retries: "{{ apt_retries }}"
   delay: "{{ apt_retry_delay }}"
-  when: update_system | default(true)
+  when: update_system | default(true) | bool
 
 - name: Upgrade packages
   become: true
@@ -20,7 +20,7 @@
   until: result is not failed
   retries: "{{ apt_retries }}"
   delay: "{{ apt_retry_delay }}"
-  when: update_system | default(true)
+  when: update_system | default(true) | bool
 
 - name: Install base system packages
   become: true

--- a/roles/dev_tools/tasks/main.yml
+++ b/roles/dev_tools/tasks/main.yml
@@ -140,6 +140,8 @@
       become: true
       ansible.builtin.shell: |
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+        chown root:root /etc/apt/keyrings/microsoft.gpg
+        chmod 0644 /etc/apt/keyrings/microsoft.gpg
       args:
         creates: /etc/apt/keyrings/microsoft.gpg
       when: install_az_cli | default(true) | bool

--- a/roles/dev_tools/tasks/main.yml
+++ b/roles/dev_tools/tasks/main.yml
@@ -14,7 +14,7 @@
         chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
       args:
         creates: /usr/share/keyrings/githubcli-archive-keyring.gpg
-      when: install_gh | default(true)
+      when: install_gh | default(true) | bool
 
     - name: Add GitHub CLI APT repository
       become: true
@@ -22,7 +22,7 @@
         repo: "deb [arch={{ deb_arch }} signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
         state: present
         filename: github-cli
-      when: install_gh | default(true)
+      when: install_gh | default(true) | bool
 
     - name: Install GitHub CLI
       become: true
@@ -30,7 +30,7 @@
         name: gh
         state: present
         update_cache: true
-      when: install_gh | default(true)
+      when: install_gh | default(true) | bool
 
     # ── Node.js (via NodeSource) ─────────────────────────────────────────────
     - name: Add NodeSource GPG key and repository
@@ -39,7 +39,7 @@
         curl -fsSL https://deb.nodesource.com/setup_{{ node_major_version }}.x | bash -
       args:
         creates: /etc/apt/sources.list.d/nodesource.list
-      when: install_node | default(true)
+      when: install_node | default(true) | bool
 
     - name: Install Node.js
       become: true
@@ -47,7 +47,7 @@
         name: nodejs
         state: present
         update_cache: true
-      when: install_node | default(true)
+      when: install_node | default(true) | bool
 
     # ── pnpm ─────────────────────────────────────────────────────────────────
     - name: Install pnpm via npm
@@ -56,8 +56,8 @@
       args:
         creates: /usr/bin/pnpm
       when:
-        - install_pnpm | default(true)
-        - install_node | default(true)
+        - install_pnpm | default(true) | bool
+        - install_node | default(true) | bool
 
     # ── uv (Python package manager) ──────────────────────────────────────────
     - name: Install uv
@@ -66,7 +66,7 @@
         curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
       args:
         creates: /usr/local/bin/uv
-      when: install_uv | default(true)
+      when: install_uv | default(true) | bool
 
     # ── pre-commit ───────────────────────────────────────────────────────────
     - name: Install pre-commit via pip (--break-system-packages for containers)
@@ -75,7 +75,7 @@
         name: pre-commit
         state: present
         extra_args: --break-system-packages
-      when: install_pre_commit | default(true)
+      when: install_pre_commit | default(true) | bool
 
     # ── Terraform ────────────────────────────────────────────────────────────
     - name: Add HashiCorp GPG key
@@ -83,14 +83,14 @@
       ansible.builtin.apt_key:
         url: https://apt.releases.hashicorp.com/gpg
         state: present
-      when: install_terraform | default(true)
+      when: install_terraform | default(true) | bool
 
     - name: Add HashiCorp APT repository
       become: true
       ansible.builtin.apt_repository:
         repo: "deb [arch={{ deb_arch }}] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
         state: present
-      when: install_terraform | default(true)
+      when: install_terraform | default(true) | bool
 
     - name: Install Terraform
       become: true
@@ -98,7 +98,7 @@
         name: terraform
         state: present
         update_cache: true
-      when: install_terraform | default(true)
+      when: install_terraform | default(true) | bool
 
     # ── Gitleaks ─────────────────────────────────────────────────────────────
     - name: Get latest Gitleaks release version
@@ -106,7 +106,7 @@
         url: https://api.github.com/repos/gitleaks/gitleaks/releases/latest
         return_content: true
       register: gitleaks_release
-      when: install_gitleaks | default(true)
+      when: install_gitleaks | default(true) | bool
 
     - name: Download and install Gitleaks binary
       become: true
@@ -119,7 +119,7 @@
       args:
         creates: /usr/local/bin/gitleaks
       when:
-        - install_gitleaks | default(true)
+        - install_gitleaks | default(true) | bool
         - gitleaks_release is succeeded
 
     # ── Azure CLI ────────────────────────────────────────────────────────────
@@ -129,7 +129,7 @@
         curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/azure-archive-keyring.gpg
       args:
         creates: /usr/share/keyrings/azure-archive-keyring.gpg
-      when: install_az_cli | default(true)
+      when: install_az_cli | default(true) | bool
 
     - name: Add Azure CLI APT repository
       become: true
@@ -137,7 +137,7 @@
         repo: "deb [arch={{ deb_arch }} signed-by=/usr/share/keyrings/azure-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main"
         state: present
         filename: azure-cli
-      when: install_az_cli | default(true)
+      when: install_az_cli | default(true) | bool
 
     - name: Install Azure CLI
       become: true
@@ -145,7 +145,7 @@
         name: azure-cli
         state: present
         update_cache: true
-      when: install_az_cli | default(true)
+      when: install_az_cli | default(true) | bool
 
     # ── Python 3.12 (for smart-agents-backend) ──────────────────────────────
     - name: Add deadsnakes PPA for Python 3.12
@@ -153,7 +153,7 @@
       ansible.builtin.apt_repository:
         repo: ppa:deadsnakes/ppa
         state: present
-      when: install_python312 | default(true)
+      when: install_python312 | default(true) | bool
 
     - name: Install Python 3.12
       become: true
@@ -164,7 +164,7 @@
           - python3.12-dev
         state: present
         update_cache: true
-      when: install_python312 | default(true)
+      when: install_python312 | default(true) | bool
 
     # ── PostgreSQL client ────────────────────────────────────────────────────
     - name: Install PostgreSQL client
@@ -172,4 +172,4 @@
       ansible.builtin.apt:
         name: postgresql-client
         state: present
-      when: install_postgresql_client | default(true)
+      when: install_postgresql_client | default(true) | bool

--- a/roles/dev_tools/tasks/main.yml
+++ b/roles/dev_tools/tasks/main.yml
@@ -123,18 +123,31 @@
         - gitleaks_release is succeeded
 
     # ── Azure CLI ────────────────────────────────────────────────────────────
+    # Keyring lives at /etc/apt/keyrings/microsoft.gpg to match the upstream
+    # Microsoft APT convention used by the pre-installed Azure CLI package on
+    # GitHub-hosted Ubuntu runners. A distinct path here collides with the
+    # pre-existing repo definition and APT fails with "Conflicting values
+    # set for option Signed-By" for packages.microsoft.com.
+    - name: Ensure /etc/apt/keyrings directory exists
+      become: true
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+      when: install_az_cli | default(true) | bool
+
     - name: Add Azure CLI GPG key
       become: true
       ansible.builtin.shell: |
-        curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/azure-archive-keyring.gpg
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
       args:
-        creates: /usr/share/keyrings/azure-archive-keyring.gpg
+        creates: /etc/apt/keyrings/microsoft.gpg
       when: install_az_cli | default(true) | bool
 
     - name: Add Azure CLI APT repository
       become: true
       ansible.builtin.apt_repository:
-        repo: "deb [arch={{ deb_arch }} signed-by=/usr/share/keyrings/azure-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main"
+        repo: "deb [arch={{ deb_arch }} signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ {{ ansible_distribution_release }} main"
         state: present
         filename: azure-cli
       when: install_az_cli | default(true) | bool


### PR DESCRIPTION
## Summary
Fixes two role bugs surfaced by the provisioning-test CI workflow (PR #20), which currently masks them with workarounds.

### Bug 1: missing `| bool` on flag `when:` clauses
Under ansible-core 2.20's strict conditional evaluation, `when: update_system | default(true)` treats the non-empty string `"false"` (from `-e update_system=false`) as truthy. Tasks then run when they should be skipped. CI works around it by writing a JSON extra-vars file.

Fix: append `| bool` to every `when:` clause whose condition is a user-overridable flag.
- `roles/base/tasks/main.yml`: 2 sites (`update_system`)
- `roles/dev_tools/tasks/main.yml`: 20 sites (`install_gh`, `install_node`, `install_pnpm`, `install_uv`, `install_pre_commit`, `install_terraform`, `install_gitleaks`, `install_az_cli`, `install_python312`, `install_postgresql_client`)

String comparisons (e.g. `ansible_facts['os_family'] == "Debian"`) are deliberately untouched.

### Bug 2: Azure CLI keyring path collision
`roles/dev_tools/tasks/main.yml` wrote the key to `/usr/share/keyrings/azure-archive-keyring.gpg`, but GitHub-hosted Ubuntu runners ship Azure CLI pre-installed with `/etc/apt/keyrings/microsoft.gpg`. APT fails with `Conflicting values set for option Signed-By` for `packages.microsoft.com`.

Fix: switch to the upstream `/etc/apt/keyrings/microsoft.gpg` path (both `signed-by=` and the key install location), and add a task to ensure `/etc/apt/keyrings/` exists on hosts that only have `/usr/share/keyrings/`.

## Test plan
- [x] `ansible-playbook --syntax-check dev.yml -i "localhost," -e host_username=dev` locally passes
- [x] `ansible-lint --show-relpath roles/base roles/dev_tools` locally passes
- [ ] `provisioning-test` CI workflow green on this PR (path-filtered to `roles/**`, runs on ubuntu-latest, ~4 min)
- [ ] Follow-up commit removes the JSON extra-vars workaround and `install_az_cli: false` from the workflow once the underlying bugs are fixed — separated so the "remove workaround" intent is clear

Pre-existing `yaml[brackets]` violation on `.github/workflows/provisioning-test.yml:17` is unrelated to this change and exists on `main`; out of scope.