### PR TITLE
fix(tasks): resolve pre-existing bugs surfaced by Copilot on #21

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -12,11 +12,6 @@ exclude_paths:
   # Existing ignore entries from the repo's conventions.
   - .cache/
   - site.retry
-  # `tasks/mount_glusterfs.yml` is referenced only from the deprecated
-  # template.yml (header says "DEPRECATED: prefer dev.yml"). The file was
-  # removed when roles/ was introduced. load-failure is unskippable, so we
-  # exclude the (virtual) missing path instead.
-  - tasks/mount_glusterfs.yml
 
 skip_list:
   # Variables in this repo use domain-oriented names (e.g. `host_username`,

--- a/tasks/create_docker_github_runner.yml
+++ b/tasks/create_docker_github_runner.yml
@@ -10,7 +10,7 @@
   ansible.builtin.file:
     path: "/mnt/env/{{ item.name }}"
     state: directory
-    mode: '0600'
+    mode: '0700'
     owner: '{{ default_volume_owner }}'
     group: '{{ default_volume_owner }}'
   with_items: "{{ github_runner_repos }}"
@@ -19,7 +19,7 @@
   ansible.builtin.file:
     path: "/mnt/env/{{ item.name }}/state"
     state: directory
-    mode: '0600'
+    mode: '0700'
     owner: '{{ default_volume_owner }}'
     group: '{{ default_volume_owner }}'
   with_items: "{{ github_runner_repos }}"

--- a/tasks/create_docker_github_runner.yml
+++ b/tasks/create_docker_github_runner.yml
@@ -12,7 +12,7 @@
     state: directory
     mode: '0700'
     owner: '{{ default_volume_owner }}'
-    group: '{{ default_volume_owner }}'
+    group: '{{ default_volume_group }}'
   with_items: "{{ github_runner_repos }}"
 
 - name: Ensure app state directory
@@ -21,7 +21,7 @@
     state: directory
     mode: '0700'
     owner: '{{ default_volume_owner }}'
-    group: '{{ default_volume_owner }}'
+    group: '{{ default_volume_group }}'
   with_items: "{{ github_runner_repos }}"
 
 - name: Create Unit file

--- a/tasks/install_code_server.yml
+++ b/tasks/install_code_server.yml
@@ -8,7 +8,7 @@
 
 - name: Install Code Server
   become: true
-  ansible.builtin.command: bash +x /tmp/install-code-server.sh
+  ansible.builtin.command: bash /tmp/install-code-server.sh
 
 - name: Check code server config file
   ansible.builtin.stat:

--- a/tasks/mount_home_glusterfs.yml
+++ b/tasks/mount_home_glusterfs.yml
@@ -2,7 +2,7 @@
 - name: Ensure glusterfs home directories
   ansible.builtin.file:
     # Extract the last part of the mount name, which is the username
-    path: "/home/{{ mount | regex_search('.+_.+_(.+)', '\\1') | first }}"
+    path: "/home/{{ mount | regex_search('.+_.+_(.+)', '\\1') }}"
     state: directory
     mode: '0755'
     owner: '{{ host_username }}'
@@ -16,7 +16,7 @@
 - name: Add GlusterFS home volumes to fstab
   ansible.builtin.lineinfile:
     path: "/etc/fstab"
-    line: "{{ glusterfs_server }}:/{{ mount }} /home/{{ mount | regex_search('.+_.+_(.+)', '\\1') | first }} glusterfs defaults,_netdev 0 0"
+    line: "{{ glusterfs_server }}:/{{ mount }} /home/{{ mount | regex_search('.+_.+_(.+)', '\\1') }} glusterfs defaults,_netdev 0 0"
     state: present
   loop: "{{ glusterfs_home_mounts_list }}"
   loop_control:

--- a/template.yml
+++ b/template.yml
@@ -43,11 +43,6 @@
       retries: '{{ apt_retries }}'
       delay: '{{ apt_retry_delay }}'
 
-    - name: Split glusterfs mounts var
-      when: glusterfs_mounts != None
-      ansible.builtin.set_fact:
-        glusterfs_mounts_list: "{{ glusterfs_mounts.split(',') }}"
-
     - name: Split glusterfs home mounts var
       when: glusterfs_home_mounts != None
       ansible.builtin.set_fact:
@@ -56,10 +51,6 @@
     - name: Mount Home glusterfs volumes
       when: glusterfs_home_mounts_list is defined
       ansible.builtin.include_tasks: tasks/mount_home_glusterfs.yml
-
-    - name: Mount Other Glusterfs volumes
-      when: glusterfs_mounts_list is defined
-      ansible.builtin.include_tasks: tasks/mount_glusterfs.yml
 
     - name: Install Docker
       ansible.builtin.include_tasks: tasks/install_docker.yml


### PR DESCRIPTION
Five pre-existing bugs flagged by Copilot review on #21 (ansible-lint cleanup). Each fix is in its own commit so they can be evaluated independently. All changes are confined to standalone `tasks/*.yml` files plus the deprecated `template.yml`; roles/ is untouched. CI's provisioning-test workflow is path-filtered on `roles/`, so only syntax-check and ansible-lint will run on this PR.

Local verification:
- `ansible-playbook --syntax-check template.yml -i "localhost," -e host_username=dev` -> OK
- `ansible-lint --show-relpath` -> same 1 pre-existing violation as `origin/main` (`yaml[brackets]` in `.github/workflows/provisioning-test.yml:17`, unrelated). No new violations introduced.

---

### 1. `tasks/install_code_server.yml:11` - stray shell flag

**Before:** `bash +x /tmp/install-code-server.sh`
**After:** `bash /tmp/install-code-server.sh`

`+x` is a shell option to disable `xtrace`, not a path to the script. The script still ran because the preceding `get_url` task already sets `mode: 'a+x'`, but the flag was misleading noise. Commit: 60dace1.

**Evidence:**
```
$ git show origin/main:tasks/install_code_server.yml | sed -n '9,11p'
- name: Install Code Server
  become: true
  ansible.builtin.command: bash +x /tmp/install-code-server.sh
```

### 2. `tasks/create_docker_github_runner.yml:13,22` - directory mode 0600

**Before:** `mode: '0600'` on `state: directory`
**After:** `mode: '0700'`

Directories need the execute bit; 0600 makes them untraversable. Matched `template.yml:113` (`~/.ssh` uses 0700). Commit: 93e1320.

**Evidence:**
```
$ git show origin/main:tasks/create_docker_github_runner.yml | sed -n '9,16p'
- name: Ensure app env directory
  ansible.builtin.file:
    path: "/mnt/env/{{ item.name }}"
    state: directory
    mode: '0600'
    owner: '{{ default_volume_owner }}'
    group: '{{ default_volume_owner }}'
  with_items: "{{ github_runner_repos }}"
```

### 3. `tasks/create_docker_github_runner.yml:15,24` - `group: default_volume_owner`

**Before:** `group: '{{ default_volume_owner }}'`
**After:** `group: '{{ default_volume_group }}'`

Copy/paste from `owner:`. `default_volume_group` is defined in every vars file alongside `default_volume_owner` (vars/bootstrap_defaults.yml, vars/pluto_defaults.yml, vars/playground_defaults.yml, vars/store_defaults.yml) and is paired with `owner` in every other task. Commit: 1c8aa81.

**Evidence:** see block above (line 15 shows `group: '{{ default_volume_owner }}'`).

### 4. `tasks/mount_home_glusterfs.yml:5,19` - `regex_search(..., '\\1') | first` truncates to 1 char

**Before:** `{{ mount | regex_search('.+_.+_(.+)', '\\1') | first }}`
**After:** `{{ mount | regex_search('.+_.+_(.+)', '\\1') }}`

`regex_search` with a backreference argument already returns the capture group as a string. `| first` then takes its first character. For a mount named `vol_host_alice`, `/home/alice` became `/home/a`. Two occurrences in the same file. Commit: 1c91d91.

**Evidence:**
```
$ git show origin/main:tasks/mount_home_glusterfs.yml | sed -n '4,6p;18,20p'
    # Extract the last part of the mount name, which is the username
    path: "/home/{{ mount | regex_search('.+_.+_(.+)', '\\1') | first }}"
    state: directory
    path: "/etc/fstab"
    line: "{{ glusterfs_server }}:/{{ mount }} /home/{{ mount | regex_search('.+_.+_(.+)', '\\1') | first }} glusterfs defaults,_netdev 0 0"
    state: present
```

### 5. `template.yml:62` - includes missing `tasks/mount_glusterfs.yml`

**Before:** `ansible.builtin.include_tasks: tasks/mount_glusterfs.yml`
**After:** include removed; also removed the now-dead `glusterfs_mounts_list` `set_fact` and the `.ansible-lint` `exclude_paths` entry that papered over the missing file.

`tasks/mount_glusterfs.yml` was deleted in commit 233f6de (May 2023) and replaced by `tasks/mount_network_volumes.yml`. The replacement is NOT a drop-in: it expects a list of dicts (`mount_path`, `name`, `type`, ...), whereas `template.yml` builds `glusterfs_mounts_list` via `glusterfs_mounts.split(',')` (list of strings). `template.yml` is already marked `DEPRECATED`, and users are directed to `dev.yml` / `pluto.yml` / `store.yml` (which use `mount_network_volumes.yml` with the correct variable shape). Commit: 5e7b779.

**Evidence:**
```
$ git show origin/main:template.yml | sed -n '60,62p'
    - name: Mount Other Glusterfs volumes
      when: glusterfs_mounts_list is defined
      ansible.builtin.include_tasks: tasks/mount_glusterfs.yml
```

The `.ansible-lint` exclude (lines 15-19 on main) is now obsolete and removed in the same commit.

---

## Test plan
- [x] `ansible-playbook --syntax-check template.yml -i "localhost," -e host_username=dev`
- [x] `ansible-lint --show-relpath` (same pre-existing baseline state, no new violations)
- [x] No `roles/` files touched, so provisioning-test is not triggered and is not expected to run