### PR TITLE
fix(ci): drop spaces inside brackets in provisioning-test trigger

### DIFF
--- a/.github/workflows/provisioning-test.yml
+++ b/.github/workflows/provisioning-test.yml
@@ -14,7 +14,7 @@ name: Ansible-Provisioning-Test
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
     paths:
       - 'roles/**'
       - 'dev.yml'


### PR DESCRIPTION
One-char fix. `branches: [ "main" ]` on .github/workflows/provisioning-test.yml:17 triggered \`yaml[brackets]: Too many spaces inside brackets\` on every ansible-lint run after PR #21 re-enabled the rule.

The matching `main.yml` workflow was tightened to `["main"]` in PR #21's mechanical sweep; `provisioning-test.yml` (merged in PR #20 before lint came back) missed that pass.

Verified locally: `ansible-lint --show-relpath .github/workflows/provisioning-test.yml` now passes.