### PR TITLE
feat(claude_code): add claudeclaw plugin from moazbuilds marketplace

### DIFF
--- a/files/claude-code/settings.json
+++ b/files/claude-code/settings.json
@@ -15,5 +15,16 @@
         ]
       }
     ]
+  },
+  "extraKnownMarketplaces": {
+    "claudeclaw": {
+      "source": {
+        "source": "github",
+        "repo": "moazbuilds/claudeclaw"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "claudeclaw@claudeclaw": true
   }
 }

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -34,10 +34,12 @@ claude_external_plugins:
 # Third-party marketplaces
 claude_custom_marketplaces:
   - JuliusBrussee/caveman
+  - moazbuilds/claudeclaw
 
 # Plugins from custom marketplaces (format: <name>@<marketplace>)
 claude_custom_plugins:
   - caveman@caveman
+  - claudeclaw@claudeclaw
 
 # ── npm packages (installed globally via `npm install -g`) ─────────────────
 # For npx-based skills/tools and MCP servers

--- a/roles/claude_code/files/settings.json
+++ b/roles/claude_code/files/settings.json
@@ -16,7 +16,8 @@
     "terraform@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "telegram@claude-plugins-official": true,
-    "caveman@caveman": true
+    "caveman@caveman": true,
+    "claudeclaw@claudeclaw": true
   },
   "mcpServers": {
     "sonarqube": {


### PR DESCRIPTION
## Why

Install [ClaudeClaw](https://github.com/moazbuilds/claudeclaw) — a cron-like daemon that runs Claude prompts on a schedule (heartbeat, scheduled jobs, Telegram/Discord notifications) — across every machine this repo provisions, mirroring the same pattern used for `caveman`.

## Summary

- **`roles/claude_code/defaults/main.yml`** — append `moazbuilds/claudeclaw` to `claude_custom_marketplaces` and `claudeclaw@claudeclaw` to `claude_custom_plugins`. The existing role tasks (`claude plugin marketplace add` + `claude plugin install`) pick these up automatically.
- **`roles/claude_code/files/settings.json`** — enable `claudeclaw@claudeclaw` under `enabledPlugins` so the plugin is active on every deploy (Ansible path).
- **`files/claude-code/settings.json`** — register the marketplace under `extraKnownMarketplaces` and enable the plugin for the standalone (non-Ansible) install path. Matches what `claude plugin install` wrote when I ran it on this Mac.

## Test plan

- [x] Ran `claude plugin marketplace add moazbuilds/claudeclaw` + `claude plugin install claudeclaw@claudeclaw` on this Mac — both succeeded.
- [x] `claude plugin list` shows `claudeclaw@claudeclaw`.
- [x] `python3 -c "import json; json.load(open(...))"` on both settings files — valid JSON.
- [ ] Re-run the Ansible role on a fresh host to confirm idempotence.