### PR TITLE
fix(claude_code): address unresolved Copilot review comments from PR #12

### DIFF
--- a/roles/claude_code/files/hooks/preserve-effort-max.sh
+++ b/roles/claude_code/files/hooks/preserve-effort-max.sh
@@ -22,6 +22,10 @@
 # fix it, the user already has the same broken state they had before.
 set -u
 
+# Hooks must never fail if HOME is unavailable in the environment. Without a
+# usable HOME we have nothing to repair, so exit cleanly.
+[ -n "${HOME:-}" ] || exit 0
+
 SETTINGS="${HOME}/.claude/settings.json"
 
 # Need python3 — present on every dev box we target. Bail silently if not.

--- a/roles/claude_code/files/hooks/preserve-effort-max.sh
+++ b/roles/claude_code/files/hooks/preserve-effort-max.sh
@@ -58,15 +58,18 @@ if data.get("effortLevel") == target:
 
 data["effortLevel"] = target
 
-# Atomic write via tmp + rename. Swallow write errors (permission denied, disk
-# full, rename failure) so the hook never blocks session start — the user keeps
-# the same state they already had.
+# Atomic write via tmp + rename. Resolve symlinks first so we update the
+# target file (e.g. the dots repo copy in `link` mode) rather than clobbering
+# the symlink itself with a regular file. Swallow write errors (permission
+# denied, disk full, rename failure) so the hook never blocks session start —
+# the user keeps the same state they already had.
 try:
-    tmp = path + ".tmp"
+    target = os.path.realpath(path)
+    tmp = target + ".tmp"
     with open(tmp, "w") as fp:
         json.dump(data, fp, indent=2)
         fp.write("\n")
-    os.replace(tmp, path)
+    os.replace(tmp, target)
 except Exception:
     sys.exit(0)
 PY

--- a/tests/test-effort-max.sh
+++ b/tests/test-effort-max.sh
@@ -37,8 +37,12 @@ echo "── Layer 2: preserve-effort-max.sh hook ──────────
 [ -x "$HOOK" ] || fail "hook not executable: $HOOK"
 [ -x "$HOOK" ] && pass "hook is executable"
 
-# Sandbox: scratch HOME with throw-away settings file
-SANDBOX="$(mktemp -d)"
+# Sandbox: scratch HOME with throw-away settings file.
+# `mktemp -d` without a template works on GNU coreutils and modern BSD; the
+# fallback `-t <prefix>` covers older BSD `mktemp` implementations that require
+# a template argument. Either call yields an absolute path on a tmpfs.
+SANDBOX="$(mktemp -d 2>/dev/null || mktemp -d -t claude-effort-max)"
+[ -n "$SANDBOX" ] && [ -d "$SANDBOX" ] || { fail "unable to create sandbox temp directory"; exit 1; }
 trap 'rm -rf "$SANDBOX"' EXIT
 mkdir -p "$SANDBOX/.claude"
 SANDBOX_SETTINGS="$SANDBOX/.claude/settings.json"


### PR DESCRIPTION
## Why

PR #12 (`feat/claude-effort-max-default`) merged with three Copilot review comments still unresolved. Addressing them in a follow-up so the hook and test script match what the reviewer flagged:

1. **Hook contradicts its own "always exit 0" contract when `HOME` is unset** — with `set -u`, dereferencing `${HOME}` raises `unbound variable` and propagates a non-zero exit, which can block `SessionStart`.
2. **Hook silently clobbers the settings.json symlink** — `os.replace(tmp, path)` on a symlink replaces the link itself with a regular file, breaking the standalone install script's and the Ansible `link` mode's "link to repo" topology the first time the hook needs to repair the key.
3. **`mktemp -d` is not portable to older BSD `mktemp`** — the tests depend on `mktemp -d` without a template, which some BSD builds reject.

## Summary

Three commits, one concern each:

- **`test(claude_code): make sandbox mktemp portable on older BSD hosts`** — fall back to `mktemp -d -t claude-effort-max` and fail loudly if both calls return nothing.
- **`fix(claude_code): guard preserve-effort-max hook against unset HOME`** — add `[ -n "${HOME:-}" ] || exit 0` before any `${HOME}` reference, so the hook short-circuits cleanly even under `set -u`.
- **`fix(claude_code): preserve settings.json symlink in atomic write`** — resolve `os.path.realpath(path)` before `os.replace`, so the hook updates the target file (the dots repo copy in `link` mode) instead of swapping the symlink for a regular file.

## Test plan

- [x] `./tests/test-effort-max.sh` — **9/9 PASS** (same suite as PR #12, now also runs cleanly with the portable `mktemp`).
- [x] Manual: `env -u HOME ./roles/claude_code/files/hooks/preserve-effort-max.sh && HOME="" ./roles/.../preserve-effort-max.sh` — both return 0.
- [x] Manual: pointed a scratch `~/.claude/settings.json` symlink at a sandbox repo file, invoked the hook, verified (a) link survives, (b) target file gained `effortLevel: max`, (c) no stray regular file replaced the link.