### PR TITLE
feat(claude_code): add claudeclaw-start wrapper that strips parent OAuth env

### DIFF
--- a/roles/claude_code/files/scripts/claudeclaw-start.sh
+++ b/roles/claude_code/files/scripts/claudeclaw-start.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# claudeclaw-start — launch the ClaudeClaw daemon with a sanitized env so the
+# bundled `claude` CLI authenticates via the platform-native credential store
+# instead of inheriting a soon-to-expire OAuth access token from the parent
+# Claude Code / Claude Desktop session.
+#
+# Why this wrapper exists
+# -----------------------
+# claudeclaw <= 1.0.0 only strips CLAUDECODE from the env it passes to spawned
+# `claude` subprocesses (src/runner.ts cleanEnv). It leaks
+# CLAUDE_CODE_OAUTH_TOKEN and CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST through.
+# When you run /claudeclaw:start from inside Claude Code/Desktop, the daemon's
+# children get a frozen OAuth access token (no refresh token to renew it) and
+# `MANAGED_BY_HOST=1` (which disables the CLI's own credential-store fallback),
+# so after ~8h every spawned claude returns HTTP 401 silently — heartbeat and
+# Telegram replies both fail with no user-visible error.
+#
+# This wrapper strips those vars before launching the daemon. After the
+# upstream fix (https://github.com/moazbuilds/claudeclaw) lands, the wrapper
+# becomes a harmless no-op (the daemon will strip them itself).
+#
+# Cross-platform
+# --------------
+# Pure POSIX shell + `env -u VAR`. Works on macOS (BSD env), Linux (GNU env),
+# and WSL2. The `claude` CLI handles per-platform credential storage:
+#   - macOS:        Keychain ("Claude Code-credentials")
+#   - Linux/WSL2:   ~/.claude/.credentials.json
+#   - Windows:      Credential Manager
+#
+# Usage
+# -----
+#   claudeclaw-start                 # launch in current dir
+#   claudeclaw-start /path/to/proj   # launch in given project dir
+#   claudeclaw-start --foreground    # run in foreground (no nohup, no &)
+#
+# Prints the launched PID on stdout.
+set -e
+
+FOREGROUND=0
+PROJECT_DIR=""
+for arg in "$@"; do
+  case "$arg" in
+    --foreground|-f) FOREGROUND=1 ;;
+    -*)              echo "claudeclaw-start: unknown option: $arg" >&2; exit 2 ;;
+    *)               [ -z "$PROJECT_DIR" ] && PROJECT_DIR="$arg" ;;
+  esac
+done
+PROJECT_DIR="${PROJECT_DIR:-$PWD}"
+
+cd "$PROJECT_DIR"
+mkdir -p .claude/claudeclaw/logs
+
+# Resolve the latest installed claudeclaw version. The plugin cache layout is
+# ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/. Sort by mtime so
+# we pick the most recently installed.
+CLAUDECLAW_DIR=$(ls -dt "$HOME/.claude/plugins/cache/claudeclaw/claudeclaw/"[0-9]*/ 2>/dev/null | head -1)
+CLAUDECLAW_DIR="${CLAUDECLAW_DIR%/}"
+if [ -z "$CLAUDECLAW_DIR" ] || [ ! -f "$CLAUDECLAW_DIR/src/index.ts" ]; then
+  echo "claudeclaw: plugin not installed at ~/.claude/plugins/cache/claudeclaw/claudeclaw/" >&2
+  echo "  install via: claude plugin marketplace add moazbuilds/claudeclaw && claude plugin install claudeclaw@claudeclaw" >&2
+  exit 1
+fi
+
+# Resolve bun. PATH may not include ~/.bun/bin when invoked from a Claude Code
+# slash command (the slash-command env can be slimmer than the user shell).
+BUN_BIN=$(command -v bun 2>/dev/null || true)
+if [ -z "$BUN_BIN" ] && [ -x "$HOME/.bun/bin/bun" ]; then
+  BUN_BIN="$HOME/.bun/bin/bun"
+fi
+if [ -z "$BUN_BIN" ] || [ ! -x "$BUN_BIN" ]; then
+  echo "claudeclaw: bun not found on PATH or at \$HOME/.bun/bin/bun" >&2
+  echo "  install via: curl -fsSL https://bun.sh/install | bash" >&2
+  exit 1
+fi
+
+# The strip set: env vars the parent Claude Code/Desktop session injects that
+# break detached daemon auth. Anything not in this list is forwarded.
+STRIP="
+  CLAUDE_CODE_OAUTH_TOKEN
+  CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST
+  CLAUDECODE
+  CLAUDE_CODE_ENTRYPOINT
+  CLAUDE_CODE_EXECPATH
+  CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH
+  CLAUDE_AGENT_SDK_VERSION
+"
+ENV_UNSET_ARGS=""
+for v in $STRIP; do ENV_UNSET_ARGS="$ENV_UNSET_ARGS -u $v"; done
+
+if [ "$FOREGROUND" = "1" ]; then
+  # shellcheck disable=SC2086
+  exec env $ENV_UNSET_ARGS "$BUN_BIN" run "$CLAUDECLAW_DIR/src/index.ts" start --web
+fi
+
+# shellcheck disable=SC2086
+nohup env $ENV_UNSET_ARGS "$BUN_BIN" run "$CLAUDECLAW_DIR/src/index.ts" start --web \
+  > .claude/claudeclaw/logs/daemon.log 2>&1 &
+echo $!

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -212,6 +212,44 @@
   loop: "{{ hook_files }}"
   when: claude_config_mode | default('link') == 'copy'
 
+# ── User-level CLI scripts (installed into ~/.local/bin/, on $PATH) ─────────
+# Wrapper scripts the user invokes from a shell or another tool. Currently:
+#
+#   claudeclaw-start.sh  →  workaround for the upstream claudeclaw bug where
+#                            the daemon inherits and re-emits the parent
+#                            CLAUDE_CODE_OAUTH_TOKEN, causing every spawned
+#                            `claude` to 401 once the parent token rotates
+#                            (~8h after Claude Desktop restart).
+#
+# Symlinks/copies into ~/.local/bin/<name without .sh>. Skip Windows since the
+# whole role only supports macOS + Linux/WSL2.
+- name: Ensure ~/.local/bin directory exists
+  ansible.builtin.file:
+    path: "{{ claude_home }}/.local/bin"
+    state: directory
+    mode: '0755'
+
+- name: List bin scripts in role (controller-side)
+  ansible.builtin.set_fact:
+    bin_scripts: "{{ query('fileglob', role_path ~ '/files/scripts/*.sh') }}"
+
+- name: Symlink each bin script into ~/.local/bin/ (without .sh suffix)
+  ansible.builtin.file:
+    src: "{{ item }}"
+    dest: "{{ claude_home }}/.local/bin/{{ item | basename | regex_replace('\\.sh$', '') }}"
+    state: link
+    force: true
+  loop: "{{ bin_scripts }}"
+  when: claude_config_mode | default('link') == 'link'
+
+- name: Copy each bin script into ~/.local/bin/ (without .sh suffix)
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ claude_home }}/.local/bin/{{ item | basename | regex_replace('\\.sh$', '') }}"
+    mode: '0755'
+  loop: "{{ bin_scripts }}"
+  when: claude_config_mode | default('link') == 'copy'
+
 # ── Plugin directory (marketplaces created by `claude plugin install`) ───────
 - name: Ensure ~/.claude/plugins directory exists
   ansible.builtin.file:


### PR DESCRIPTION
## Why

claudeclaw <= 1.0.0 only strips `CLAUDECODE` from the env it forwards to spawned `claude` subprocesses (`src/runner.ts` cleanEnv). It leaks `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST=1` through. When `/claudeclaw:start` is invoked from inside Claude Code/Desktop, the daemon's spawned `claude` processes get a frozen OAuth access token (no refresh path) plus a "host manages auth" flag that disables the CLI's own credential-store fallback. After ~8 h the token expires and every heartbeat / Telegram / Discord run silently `401`s.

**Hit this on my Mac yesterday** — daemon log showed `Done: heartbeat` for 9 hours but every per-run log file contained `API Error: 401`. Cost a couple hours to diagnose.

Upstream fix is in review: https://github.com/moazbuilds/claudeclaw/pull/102. This PR is the local workaround so the role's users don't have to re-discover the bug while we wait for upstream.

## Summary

Two files, both new:

| File | Purpose |
|---|---|
| `roles/claude_code/files/scripts/claudeclaw-start.sh` | POSIX-shell wrapper that strips the parent env vars (and a few related Claude-Desktop-injected ones) before `exec`ing `bun` on the installed claudeclaw bundle. Supports an optional project-dir arg and `--foreground`/`-f` for testing. |
| `roles/claude_code/tasks/main.yml` (new "User-level CLI scripts" block) | Mirrors the existing Hooks block — `query('fileglob', ...)` + per-mode link/copy. Drops the `.sh` suffix on the installed name (`~/.local/bin/claudeclaw-start`). |

After the upstream fix ships, the wrapper becomes a no-op env strip and can be removed.

## Cross-platform

- Wrapper: pure POSIX shell + `env -u VAR`. Works on macOS (BSD `env`) and Linux/WSL2 (GNU `env`). Matches the existing dots `claude_code` role scope (no Windows path).
- The `claude` CLI it spawns then resolves credentials per-OS (Keychain on macOS, `~/.claude/.credentials.json` on Linux), no extra logic needed in this repo.

## Test plan

- [x] **Symlink resolves**: `ls -la ~/.local/bin/claudeclaw-start` → points to role file
- [x] **Killed broken daemon, relaunched via wrapper**: `~/.local/bin/claudeclaw-start` → new daemon up, `ps eww $PID` confirms `CLAUDE_CODE_OAUTH_TOKEN` and `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST` absent
- [x] **End-to-end auth**: `env -u CLAUDE_CODE_OAUTH_TOKEN -u CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST claude --print "say PONG"` → `PONG` (uses Keychain, auto-refreshing)
- [ ] Re-run the role on a fresh host (and on a Linux box) to confirm idempotence — flagging for after merge.