### PR TITLE
feat(claude_code,bun,shell): complete ClaudeClaw lifecycle for fresh machines

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -8,6 +8,7 @@
     git_enabled: true
     docker_enabled: true
     dev_tools_enabled: true
+    bun_enabled: true
     claude_code_enabled: true
     ssh_enabled: true
   roles:
@@ -21,6 +22,10 @@
       when: docker_enabled | bool
     - role: dev_tools
       when: dev_tools_enabled | bool
+    # bun before claude_code — the claudeclaw-start wrapper (deployed by
+    # claude_code) calls into ~/.bun/bin/bun.
+    - role: bun
+      when: bun_enabled | bool
     - role: claude_code
       when: claude_code_enabled | bool
     - role: ssh

--- a/mac.yml
+++ b/mac.yml
@@ -13,11 +13,15 @@
     ssh_enabled: false
     shell_enabled: true
     git_enabled: true
+    bun_enabled: true
     claude_code_enabled: true
   roles:
     - role: shell
       when: shell_enabled | bool
     - role: git
       when: git_enabled | bool
+    # bun before claude_code — claudeclaw daemon + the wrapper both need it.
+    - role: bun
+      when: bun_enabled | bool
     - role: claude_code
       when: claude_code_enabled | bool

--- a/roles/bun/defaults/main.yml
+++ b/roles/bun/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# roles/bun — Install the Bun JavaScript runtime
+#
+# Bun is required by the ClaudeClaw plugin (it runs `bun run src/index.ts`).
+# The role installs into `~/.bun/bin/bun` via the official installer script,
+# the same path the upstream plugin expects on every platform.
+
+bun_enabled: true
+
+# Target home. Defaults to the current user's $HOME on both macOS and Linux.
+#
+# For Docker / remote-provisioning runs that install for a different account,
+# override explicitly: `ansible-playbook dev.yml -e bun_home=/home/builder`.
+# We intentionally do not infer this from `host_username` — that variable is
+# defined by roles/shell/defaults/main.yml (as `ansible_user_id`) and on macOS
+# would produce the wrong path (`/home/user` instead of `/Users/user`).
+bun_home: "{{ ansible_facts['env']['HOME'] }}"

--- a/roles/bun/tasks/main.yml
+++ b/roles/bun/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# roles/bun — Install the Bun JS runtime via the official installer.
+#
+# The official script (https://bun.sh/install) supports macOS, Linux, and
+# WSL2 with a single code path and lands the binary at `~/.bun/bin/bun` on
+# every platform — matches what ClaudeClaw and the `claudeclaw-start`
+# wrapper (in roles/claude_code) expect.
+#
+# `creates:` on the shell task gives us idempotence: the installer only
+# runs when the binary is absent. Re-running the playbook against an
+# already-provisioned host is a no-op.
+
+- name: Ensure curl is available (Debian)
+  ansible.builtin.apt:
+    name: curl
+    state: present
+    update_cache: true
+  become: true
+  when: ansible_facts['os_family'] == "Debian"
+  tags: ['bun']
+
+- name: Check if bun binary already exists
+  ansible.builtin.stat:
+    path: "{{ bun_home }}/.bun/bin/bun"
+  register: bun_binary
+  tags: ['bun']
+
+- name: Install bun via official installer
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      curl -fsSL https://bun.sh/install | bash
+    executable: /bin/bash
+    creates: "{{ bun_home }}/.bun/bin/bun"
+  environment:
+    # Pin install target so the installer respects our host_username override
+    # for Docker / remote runs. Without this the installer uses $HOME, which
+    # may differ from the target account under become_user.
+    BUN_INSTALL: "{{ bun_home }}/.bun"
+  when: not bun_binary.stat.exists
+  tags: ['bun']
+
+- name: Record bun version (for visibility in run output)
+  ansible.builtin.command: "{{ bun_home }}/.bun/bin/bun --version"
+  register: bun_version
+  changed_when: false
+  check_mode: false
+  tags: ['bun']
+
+- name: Show installed bun version
+  ansible.builtin.debug:
+    msg: "bun {{ bun_version.stdout }} at {{ bun_home }}/.bun/bin/bun"
+  tags: ['bun']

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -10,8 +10,21 @@ dotfiles_dir: "{{ playbook_dir }}"
 # Config install mode: "link" for local dev (symlinks), "copy" for Docker (files copied)
 claude_config_mode: link
 
-# Target home directory (defaults to current user, override for Docker with host_username)
-claude_home: "{{ '/home/' + host_username if host_username is defined else ansible_facts['env']['HOME'] }}"
+# Target home directory.
+#
+# link mode (local dev): always uses the current user's $HOME — works on
+# macOS (/Users/<user>), Linux, and WSL2 identically.
+#
+# copy mode (Docker / remote): uses /home/<host_username> when host_username
+# is set, so a container image built under user 'builder' gets
+# /home/builder/.claude regardless of the controller's HOME.
+#
+# The previous `if host_username is defined` pattern inadvertently matched on
+# macOS too — roles/shell/defaults/main.yml defines host_username globally
+# as ansible_user_id, so on a macOS host shell+claude_code would try to
+# write to /home/<user>, which SIP refuses. Gating on claude_config_mode
+# keeps Docker behaviour intact and makes link mode correct everywhere.
+claude_home: "{{ '/home/' + host_username if claude_config_mode | default('link') == 'copy' and host_username is defined else ansible_facts['env']['HOME'] }}"
 
 # ── Marketplace plugins (installed via `claude plugin install <name>`) ──────
 claude_plugins:

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -69,3 +69,25 @@ deploy_skills: true
 
 # ── Local commands (deployed from files/commands/<name>.md) ────────────────
 deploy_commands: true
+
+# ── ClaudeClaw auto-start (launchd on macOS, systemd user on Linux) ─────────
+# When enabled, dots deploys a user-level service that runs
+# `claudeclaw-start --foreground` against the specified project directory
+# at login / boot. The service restarts on failure (not on clean exit) and
+# logs to <project>/.claude/claudeclaw/logs/{launchd,systemd}.{log,err}.
+#
+# Set claudeclaw_autostart_project_dir explicitly — the role fails loudly
+# if autostart is enabled without it, since every user's project path is
+# different and guessing would be wrong.
+#
+# Loading is opt-in (claudeclaw_autostart_load) so a provisioning run
+# against a host with the daemon already running via the wrapper doesn't
+# fight it for the web port. Flip to true once you're ready to hand off.
+#
+# Overrides:
+#   -e claudeclaw_autostart_enabled=true
+#   -e claudeclaw_autostart_project_dir=/Users/<you>/projects/<project>
+#   -e claudeclaw_autostart_load=true
+claudeclaw_autostart_enabled: false
+claudeclaw_autostart_project_dir: ""
+claudeclaw_autostart_load: false

--- a/roles/claude_code/files/claudeclaw/env.example
+++ b/roles/claude_code/files/claudeclaw/env.example
@@ -1,0 +1,37 @@
+# ~/.config/claudeclaw/env — user-level secrets for the ClaudeClaw daemon.
+#
+# ▸ Copy this file to ~/.config/claudeclaw/env and fill in the values
+#   you use. Anything left commented stays unset.
+# ▸ The `claudeclaw-start` wrapper (from roles/claude_code) sources this
+#   file before launching the daemon, so these exports become env vars
+#   in the daemon process. ClaudeClaw then substitutes $VAR references
+#   in settings.json at load time (requires upstream env-var substitution
+#   support — https://github.com/moazbuilds/claudeclaw/pull/103).
+#
+# ▸ NEVER commit this file. It lives in ~/.config/claudeclaw/ and is
+#   gitignored by every project that uses ClaudeClaw. Dots ships only
+#   env.example; the real `env` is yours to create and manage.
+#
+# ▸ Shell syntax — this file is sourced as bash, so use `export NAME=value`.
+#   Surround values with quotes if they contain spaces or special chars.
+
+# ── Anthropic / Claude ───────────────────────────────────────────────────────
+#
+# Leave blank on macOS / Linux desktops — `claudeclaw-start` strips the
+# parent Claude Code OAuth token so the spawned `claude` CLI falls back to
+# the platform credential store (Keychain on macOS, ~/.claude/.credentials.json
+# on Linux) which refreshes automatically. Set only if you prefer to run
+# against a long-lived API key (e.g. on a headless VPS without keychain).
+#
+#export ANTHROPIC_API_KEY=
+
+# ── GLM (Z.AI) — used when model='glm' or as fallback ────────────────────────
+# Get from https://z.ai/
+#export GLM_API_KEY=
+
+# ── Telegram bot — get token from @BotFather ─────────────────────────────────
+#export TELEGRAM_BOT_TOKEN=
+
+# ── Discord bot — https://discord.com/developers/applications ────────────────
+# Enable "Message Content Intent" under Privileged Gateway Intents.
+#export DISCORD_BOT_TOKEN=

--- a/roles/claude_code/files/scripts/claudeclaw-start.sh
+++ b/roles/claude_code/files/scripts/claudeclaw-start.sh
@@ -50,6 +50,37 @@ PROJECT_DIR="${PROJECT_DIR:-$PWD}"
 cd "$PROJECT_DIR"
 mkdir -p .claude/claudeclaw/logs
 
+# ── User-level config (shared across every project) ────────────────────────
+# ~/.config/claudeclaw/env       sourced for $VAR substitution in settings
+# ~/.config/claudeclaw/settings.template.json    copied into new projects
+# Both are deployed by the dots `claude_code` role; optional for users
+# who install claudeclaw outside of dots.
+USER_CLAUDECLAW_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/claudeclaw"
+USER_ENV_FILE="$USER_CLAUDECLAW_DIR/env"
+USER_SETTINGS_TEMPLATE="$USER_CLAUDECLAW_DIR/settings.template.json"
+PROJECT_SETTINGS=".claude/claudeclaw/settings.json"
+
+# Source user-level env file if present so exported secrets become env vars
+# in the daemon process. ClaudeClaw then substitutes $VAR references in
+# settings.json at load time (requires claudeclaw >= the env-substitution
+# PR: https://github.com/moazbuilds/claudeclaw/pull/103; on older claudeclaw
+# the placeholder strings pass through literally and the user sees the
+# warning in daemon.log — safe but non-functional until upgrade).
+if [ -r "$USER_ENV_FILE" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "$USER_ENV_FILE"
+  set +a
+fi
+
+# Seed project settings from the user-level template on first launch.
+# Never overwrite an existing per-project settings.json — that belongs to
+# the project (and may have secrets the user edited in directly).
+if [ ! -f "$PROJECT_SETTINGS" ] && [ -r "$USER_SETTINGS_TEMPLATE" ]; then
+  cp "$USER_SETTINGS_TEMPLATE" "$PROJECT_SETTINGS"
+  echo "claudeclaw-start: seeded $PROJECT_SETTINGS from $USER_SETTINGS_TEMPLATE" >&2
+fi
+
 # Resolve the latest installed claudeclaw version. The plugin cache layout is
 # ~/.claude/plugins/cache/<marketplace>/<plugin>/<version>/. Sort by mtime so
 # we pick the most recently installed.

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -288,6 +288,110 @@
     mode: '0600'
   tags: ['claudeclaw']
 
+# ── ClaudeClaw auto-start (launchd / systemd user) ─────────────────────────
+# Gate on claudeclaw_autostart_enabled — default off. When on, require the
+# project directory so the rendered service knows where to cd.
+- name: Validate claudeclaw_autostart_project_dir when autostart is enabled
+  ansible.builtin.assert:
+    that:
+      - claudeclaw_autostart_project_dir | length > 0
+    fail_msg: >
+      claudeclaw_autostart_enabled=true but claudeclaw_autostart_project_dir
+      is empty. Set an absolute path like
+      `-e claudeclaw_autostart_project_dir=/Users/you/projects/thing`.
+  when: claudeclaw_autostart_enabled | bool
+  tags: ['claudeclaw', 'autostart']
+
+# --- macOS: launchd user-agent ---
+- name: Ensure ~/Library/LaunchAgents exists (macOS)
+  ansible.builtin.file:
+    path: "{{ claude_home }}/Library/LaunchAgents"
+    state: directory
+    mode: '0755'
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - ansible_facts['os_family'] == "Darwin"
+  tags: ['claudeclaw', 'autostart']
+
+- name: Render launchd plist for ClaudeClaw (macOS)
+  ansible.builtin.template:
+    src: claudeclaw.plist.j2
+    dest: "{{ claude_home }}/Library/LaunchAgents/sh.claudeclaw.daemon.plist"
+    mode: '0644'
+  register: _claudeclaw_plist
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - ansible_facts['os_family'] == "Darwin"
+  tags: ['claudeclaw', 'autostart']
+
+- name: Reload launchd agent when plist changes (macOS)
+  # bootout is idempotent-enough: succeeds if loaded, 'not loaded' if not.
+  # bootstrap then loads with the current plist contents. failed_when: false
+  # absorbs the expected 'not currently loaded' exit code on first run.
+  ansible.builtin.shell: |
+    set -e
+    uid=$(id -u)
+    launchctl bootout "gui/$uid/sh.claudeclaw.daemon" 2>/dev/null || true
+    launchctl bootstrap "gui/$uid" "{{ claude_home }}/Library/LaunchAgents/sh.claudeclaw.daemon.plist"
+  changed_when: true
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - claudeclaw_autostart_load | bool
+    - ansible_facts['os_family'] == "Darwin"
+    - _claudeclaw_plist is changed
+  tags: ['claudeclaw', 'autostart']
+
+# --- Linux: systemd --user service ---
+- name: Ensure ~/.config/systemd/user exists (Linux)
+  ansible.builtin.file:
+    path: "{{ claude_home }}/.config/systemd/user"
+    state: directory
+    mode: '0755'
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - ansible_facts['os_family'] != "Darwin"
+  tags: ['claudeclaw', 'autostart']
+
+- name: Render systemd user service for ClaudeClaw (Linux)
+  ansible.builtin.template:
+    src: claudeclaw.service.j2
+    dest: "{{ claude_home }}/.config/systemd/user/claudeclaw.service"
+    mode: '0644'
+  register: _claudeclaw_service
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - ansible_facts['os_family'] != "Darwin"
+  tags: ['claudeclaw', 'autostart']
+
+- name: Enable + (re)start ClaudeClaw systemd user service (Linux)
+  ansible.builtin.systemd_service:
+    name: claudeclaw.service
+    scope: user
+    daemon_reload: true
+    enabled: true
+    state: "{{ 'restarted' if _claudeclaw_service is changed else 'started' }}"
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - claudeclaw_autostart_load | bool
+    - ansible_facts['os_family'] != "Darwin"
+  tags: ['claudeclaw', 'autostart']
+
+- name: Autostart summary (tells user the manual load command if load=false)
+  ansible.builtin.debug:
+    msg: |
+      ClaudeClaw autostart file deployed but NOT loaded (claudeclaw_autostart_load=false).
+      To load manually:
+      {% if ansible_facts['os_family'] == 'Darwin' %}
+        launchctl bootstrap gui/$(id -u) {{ claude_home }}/Library/LaunchAgents/sh.claudeclaw.daemon.plist
+      {% else %}
+        systemctl --user daemon-reload
+        systemctl --user enable --now claudeclaw.service
+      {% endif %}
+  when:
+    - claudeclaw_autostart_enabled | bool
+    - not claudeclaw_autostart_load | bool
+  tags: ['claudeclaw', 'autostart']
+
 # ── Plugin directory (marketplaces created by `claude plugin install`) ───────
 - name: Ensure ~/.claude/plugins directory exists
   ansible.builtin.file:

--- a/roles/claude_code/tasks/main.yml
+++ b/roles/claude_code/tasks/main.yml
@@ -250,6 +250,44 @@
   loop: "{{ bin_scripts }}"
   when: claude_config_mode | default('link') == 'copy'
 
+# ── ClaudeClaw user-level config (template + env example) ───────────────────
+# Dots ships two files into ~/.config/claudeclaw/:
+#
+#   settings.template.json  Rendered from claudeclaw-settings.json.j2 using
+#                           the Ansible vars listed at the top of the
+#                           template. `claudeclaw-start` copies this file
+#                           into <project>/.claude/claudeclaw/settings.json
+#                           the first time the daemon is launched in that
+#                           project (never overwrites existing settings).
+#
+#   env.example             Documented list of secret env vars the daemon
+#                           consumes via $VAR substitution in settings.
+#                           User copies this to ~/.config/claudeclaw/env
+#                           and fills in values. We never ship or rewrite
+#                           the real `env` file — it's gitignored user data.
+#
+# Directory mode 0700: contains secrets once the user populates env.
+- name: Ensure ~/.config/claudeclaw directory exists
+  ansible.builtin.file:
+    path: "{{ claude_home }}/.config/claudeclaw"
+    state: directory
+    mode: '0700'
+  tags: ['claudeclaw']
+
+- name: Render ClaudeClaw settings template to ~/.config/claudeclaw/
+  ansible.builtin.template:
+    src: claudeclaw-settings.json.j2
+    dest: "{{ claude_home }}/.config/claudeclaw/settings.template.json"
+    mode: '0644'
+  tags: ['claudeclaw']
+
+- name: Deploy ClaudeClaw env.example (never overwrite user's env)
+  ansible.builtin.copy:
+    src: claudeclaw/env.example
+    dest: "{{ claude_home }}/.config/claudeclaw/env.example"
+    mode: '0600'
+  tags: ['claudeclaw']
+
 # ── Plugin directory (marketplaces created by `claude plugin install`) ───────
 - name: Ensure ~/.claude/plugins directory exists
   ansible.builtin.file:

--- a/roles/claude_code/templates/claudeclaw-settings.json.j2
+++ b/roles/claude_code/templates/claudeclaw-settings.json.j2
@@ -1,0 +1,71 @@
+{# Managed by dots — ~/.config/claudeclaw/settings.template.json
+
+This template seeds per-project settings at `<project>/.claude/claudeclaw/settings.json`
+on first `claudeclaw-start` in a new directory. Non-secret defaults come from the
+Ansible vars below; secrets live in `~/.config/claudeclaw/env` and are resolved by
+ClaudeClaw at load time (requires the env-var-substitution feature — see
+https://github.com/moazbuilds/claudeclaw/pull/103).
+
+Override any field per-host via group_vars / host_vars or `-e claudeclaw_<field>=...`:
+
+  claudeclaw_model                  opus | sonnet | haiku | glm
+  claudeclaw_fallback_model         glm (or empty to disable fallback)
+  claudeclaw_agentic_enabled        true | false
+  claudeclaw_session_timeout_ms     default 1200000 (20 min)
+  claudeclaw_timezone               UTC, UTC+10, UTC-5, etc.
+  claudeclaw_heartbeat_enabled      true | false
+  claudeclaw_heartbeat_interval     minutes
+  claudeclaw_heartbeat_prompt       inline string OR a file path like 'prompts/heartbeat.md'
+  claudeclaw_telegram_user_ids      list of numeric Telegram user IDs
+  claudeclaw_discord_user_ids       list of string Discord snowflake IDs
+  claudeclaw_discord_channels       list of string Discord channel IDs
+  claudeclaw_security_level         locked | strict | moderate | unrestricted
+  claudeclaw_security_allowed       list of `Bash(git:*)`-style tool specs
+  claudeclaw_security_disallowed    list of tool specs to block
+-#}
+{
+  "model": "{{ claudeclaw_model | default('opus') }}",
+  "api": "$ANTHROPIC_API_KEY",
+  "sessionTimeoutMs": {{ claudeclaw_session_timeout_ms | default(1200000) }},
+  "fallback": {
+    "model": "{{ claudeclaw_fallback_model | default('glm') }}",
+    "api": "$GLM_API_KEY"
+  },
+  "agentic": {
+    "enabled": {{ claudeclaw_agentic_enabled | default(true) | tojson }},
+    "defaultMode": "implementation",
+    "modes": [
+      {
+        "name": "planning",
+        "model": "{{ claudeclaw_planning_model | default('opus') }}",
+        "keywords": ["plan", "design", "architect", "research", "analyze", "think", "evaluate", "review"],
+        "phrases": ["how should i", "what's the best way to", "help me decide"]
+      },
+      {
+        "name": "implementation",
+        "model": "{{ claudeclaw_implementation_model | default('sonnet') }}",
+        "keywords": ["implement", "code", "write", "fix", "deploy", "test", "commit"]
+      }
+    ]
+  },
+  "timezone": "{{ claudeclaw_timezone | default('UTC') }}",
+  "heartbeat": {
+    "enabled": {{ claudeclaw_heartbeat_enabled | default(false) | tojson }},
+    "interval": {{ claudeclaw_heartbeat_interval | default(15) }},
+    "prompt": {{ claudeclaw_heartbeat_prompt | default('') | tojson }}
+  },
+  "telegram": {
+    "token": "$TELEGRAM_BOT_TOKEN",
+    "allowedUserIds": {{ claudeclaw_telegram_user_ids | default([]) | tojson }}
+  },
+  "discord": {
+    "token": "$DISCORD_BOT_TOKEN",
+    "allowedUserIds": {{ claudeclaw_discord_user_ids | default([]) | tojson }},
+    "listenChannels": {{ claudeclaw_discord_channels | default([]) | tojson }}
+  },
+  "security": {
+    "level": "{{ claudeclaw_security_level | default('moderate') }}",
+    "allowedTools": {{ claudeclaw_security_allowed | default([]) | tojson }},
+    "disallowedTools": {{ claudeclaw_security_disallowed | default([]) | tojson }}
+  }
+}

--- a/roles/claude_code/templates/claudeclaw.plist.j2
+++ b/roles/claude_code/templates/claudeclaw.plist.j2
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  launchd user-agent for the ClaudeClaw daemon.
+  Rendered by roles/claude_code from claudeclaw.plist.j2.
+
+  Installed at: ~/Library/LaunchAgents/sh.claudeclaw.daemon.plist
+  Load:   launchctl bootstrap gui/$UID ~/Library/LaunchAgents/sh.claudeclaw.daemon.plist
+  Unload: launchctl bootout   gui/$UID/sh.claudeclaw.daemon
+  Status: launchctl print     gui/$UID/sh.claudeclaw.daemon
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>sh.claudeclaw.daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{ claude_home }}/.local/bin/claudeclaw-start</string>
+        <string>--foreground</string>
+        <string>{{ claudeclaw_autostart_project_dir }}</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>{{ claudeclaw_autostart_project_dir }}</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>{{ claudeclaw_autostart_project_dir }}/.claude/claudeclaw/logs/launchd.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{ claudeclaw_autostart_project_dir }}/.claude/claudeclaw/logs/launchd.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{ claude_home }}</string>
+        <key>PATH</key>
+        <string>{{ claude_home }}/.bun/bin:{{ claude_home }}/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/roles/claude_code/templates/claudeclaw.service.j2
+++ b/roles/claude_code/templates/claudeclaw.service.j2
@@ -1,0 +1,28 @@
+# systemd user service for the ClaudeClaw daemon.
+# Rendered by roles/claude_code from claudeclaw.service.j2.
+#
+# Installed at: ~/.config/systemd/user/claudeclaw.service
+# Enable:  systemctl --user daemon-reload && systemctl --user enable --now claudeclaw.service
+# Status:  systemctl --user status claudeclaw.service
+# Logs:    journalctl --user -u claudeclaw.service -f
+# Disable: systemctl --user disable --now claudeclaw.service
+
+[Unit]
+Description=ClaudeClaw daemon ({{ claudeclaw_autostart_project_dir }})
+Documentation=https://github.com/moazbuilds/claudeclaw
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory={{ claudeclaw_autostart_project_dir }}
+ExecStart={{ claude_home }}/.local/bin/claudeclaw-start --foreground {{ claudeclaw_autostart_project_dir }}
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:{{ claudeclaw_autostart_project_dir }}/.claude/claudeclaw/logs/systemd.log
+StandardError=append:{{ claudeclaw_autostart_project_dir }}/.claude/claudeclaw/logs/systemd.err
+Environment=HOME={{ claude_home }}
+Environment=PATH={{ claude_home }}/.bun/bin:{{ claude_home }}/.local/bin:/usr/local/bin:/usr/bin:/bin
+
+[Install]
+WantedBy=default.target

--- a/roles/shell/tasks/main.yml
+++ b/roles/shell/tasks/main.yml
@@ -50,3 +50,35 @@
     group: "{{ host_username }}"
   when: ansible_facts['os_family'] != "Darwin"
   tags: ['user_dots', 'dots']
+
+# ── ~/.local/bin on PATH ─────────────────────────────────────────────────────
+# Adds a marker-delimited block to ~/.bashrc and ~/.zshrc that puts
+# ~/.local/bin on PATH when it isn't already there. Needed by the
+# claude_code role's `claudeclaw-start` wrapper (and any other
+# user-level scripts deployed under files/scripts/ in future roles).
+#
+# Uses `blockinfile` for idempotent round-trip — the block is rewritten
+# in place on re-runs and can be cleanly removed by deleting the
+# marker lines. The runtime `case` guard prevents the PATH from
+# growing on every shell spawn when the block is evaluated more than
+# once (parent + child shell).
+- name: Resolve target home for rc files
+  ansible.builtin.set_fact:
+    _rc_home: "{{ ansible_facts['env']['HOME'] if ansible_facts['os_family'] == 'Darwin' else '/home/' + host_username }}"
+  tags: ['user_dots', 'dots', 'path']
+
+- name: Ensure ~/.local/bin is on PATH (shell rc files)
+  ansible.builtin.blockinfile:
+    path: "{{ _rc_home }}/{{ item }}"
+    marker: "# {mark} dots: ~/.local/bin on PATH"
+    create: true
+    mode: '0644'
+    block: |
+      case ":$PATH:" in
+        *":$HOME/.local/bin:"*) ;;
+        *) export PATH="$HOME/.local/bin:$PATH" ;;
+      esac
+  loop:
+    - .bashrc
+    - .zshrc
+  tags: ['user_dots', 'dots', 'path']


### PR DESCRIPTION
## Why

After PR #25 (plugin install) and PR #27 (OAuth-strip wrapper), dots *starts* claudeclaw on a machine that already has Bun, `~/.local/bin` on PATH, and a hand-filled `settings.json`. This PR closes the loop: a fresh `ansible-playbook mac.yml` run now produces a box where `cd <project> && claudeclaw-start` just works — and optionally, a login-scope service that keeps the daemon alive across logout / reboot.

Every piece is **generic**, not Telegram-specific — env-var substitution (upstream claudeclaw PR [#103](https://github.com/moazbuilds/claudeclaw/pull/103)) resolves `$VAR` references anywhere in settings, so any secret (Anthropic, GLM, Telegram, Discord, future fields) routes through the same `~/.config/claudeclaw/env` file.

## Scope (5 commits, one concern each)

| Commit | Purpose |
|---|---|
| `feat(bun)` | New `roles/bun/` installs Bun into `$HOME/.bun` on macOS + Debian via the official installer, `creates:`-guarded for idempotence. Wired into both `mac.yml` and `dev.yml` before `claude_code`. |
| `feat(shell)` | Marker-delimited `blockinfile` adds `~/.local/bin` to PATH in both `~/.bashrc` and `~/.zshrc`. Runtime `case` guard keeps PATH idempotent even when the rc is evaluated twice. |
| `feat(claude_code) — template` | User-level `settings.template.json` + `env.example` deployed to `~/.config/claudeclaw/` (mode `0700`). Template is rendered from Jinja2 with non-secret Ansible-var defaults; secrets are `$VAR` placeholders resolved at claudeclaw load time. Also fixes a latent `claude_home` bug (details below). |
| `feat(claude_code) — wrapper` | `claudeclaw-start` sources `~/.config/claudeclaw/env` (exports become daemon env vars) and seeds `<project>/.claude/claudeclaw/settings.json` from the user-level template the first time the daemon launches in a new project. Never overwrites existing per-project settings. |
| `feat(claude_code) — autostart` | Optional `~/Library/LaunchAgents/sh.claudeclaw.daemon.plist` on macOS + `~/.config/systemd/user/claudeclaw.service` on Linux. Deploy-only by default; `claudeclaw_autostart_load=true` hands off to the service. Logs to the same `<project>/.claude/claudeclaw/logs/` directory. |

## Ansible patterns

- **`ansible.builtin.template`** + Jinja2 for every variable-driven file (no runtime `envsubst` / `sed`).
- **`lineinfile` / `blockinfile`** for rc-file edits with `{mark}`-delimited regions so re-runs are clean round-trips and cleanup is a one-liner.
- **`creates:`** on the Bun install `shell` task — idempotent by contract, re-runs are no-ops.
- **Platform detection via `ansible_facts['os_family']`** in task `when:` guards.
- **`scope: user`** for systemd, `gui/$UID/...` for launchctl — never touches system-level.
- **`become:`** scoped only where needed (apt install of curl on Debian).
- **Tags** on every task so you can target with `--tags bun`, `--tags path`, `--tags claudeclaw`, `--tags autostart`.
- **Defaults in `roles/*/defaults/main.yml`** with sane values so a zero-var run does the right thing; all tunables documented inline.

## Pre-existing bug also fixed here

`roles/claude_code/defaults/main.yml` set `claude_home` to `"{{ '/home/' + host_username if host_username is defined else HOME }}"`. That was intended for Docker `copy` mode but accidentally matched macOS too, because `roles/shell/defaults/main.yml` defines `host_username: ansible_user_id` globally. On a Mac, every subsequent `file:` / `copy:` task in `claude_code` tried to write to `/home/<user>` — a path SIP refuses to create — so the role silently failed whenever `shell` also ran.

The fix gates on `claude_config_mode == 'copy'` instead of `host_username is defined`, matching intent: copy mode = Docker (Linux paths), link mode = local dev (HOME, any OS). The same root cause existed in my first-draft `bun_home` default and is fixed the same way.

## Generic, not Telegram-only

Every `$VAR` in the template is arbitrary — `$ANTHROPIC_API_KEY`, `$GLM_API_KEY`, `$TELEGRAM_BOT_TOKEN`, `$DISCORD_BOT_TOKEN`, and anything you add to `env.example` in future. claudeclaw's env-substitution (upstream [#103](https://github.com/moazbuilds/claudeclaw/pull/103)) walks every string leaf of the settings JSON, so new fields in future claudeclaw releases participate automatically with zero per-field plumbing here.

## Test plan

### Local (this Mac)

- [x] `ansible-playbook mac.yml --syntax-check` — clean
- [x] `ansible-lint` — 0 failures, 0 warnings on all 65 processed files
- [x] `ansible-playbook mac.yml --tags bun` — `bun 1.3.13 at /Users/.../.bun/bin/bun`, idempotent on re-run
- [x] `ansible-playbook mac.yml --tags path` — adds block to `~/.zshrc`, re-run is no-op
- [x] `ansible-playbook mac.yml --tags claudeclaw` — deploys template + env.example, valid JSON rendering, `~/.config/claudeclaw/` mode `0700`
- [x] Wrapper end-to-end: `mktemp -d && cd && claudeclaw-start --foreground` → seeded settings.json message, daemon up, Telegram enabled (token resolved from `~/.config/claudeclaw/env`)
- [x] Autostart deploy-only: `-e claudeclaw_autostart_enabled=true -e claudeclaw_autostart_project_dir=/tmp/x` → plist deployed at correct path, contents render correctly, debug message prints the manual load command
- [ ] Autostart `claudeclaw_autostart_load=true` — not exercised locally (would fight the already-running wrapper daemon on this machine for port 4632); will run once this branch merges and I transition to the service.

### CI (covered by existing workflows)

- `ansible-lint` workflow — standard
- Provisioning test workflow (`dev.yml` on `ubuntu-latest`) — exercises `bun` + `shell` + `claude_code` end-to-end on Linux, including autostart-disabled path

## Companion upstream PRs

- [moazbuilds/claudeclaw#102](https://github.com/moazbuilds/claudeclaw/pull/102) — OAuth env-strip at the spawn site (daemon never inherits the parent's frozen token)
- [moazbuilds/claudeclaw#103](https://github.com/moazbuilds/claudeclaw/pull/103) — env-var substitution in settings.json (the `$VAR` feature this PR's template relies on)

The wrapper + env file here work fine on pre-#103 claudeclaw (`$VAR` passes through literally with a warning); it just isn't *useful* until #103 lands. Once both upstream PRs ship, the local wrapper becomes mostly a no-op OAuth-strip shim which is clean to remove.

## Risk

Low. Everything is opt-in by default:
- Autostart disabled by default; no service ever deploys unless explicitly enabled.
- Wrapper changes are additive — the old "just strip env + launch" path still runs when `~/.config/claudeclaw/` is absent.
- No existing file is ever overwritten without explicit intent (env.example is the template, env is never touched; per-project settings.json is only seeded when absent).

The `claude_home` fix changes one default's evaluation on macOS — from broken `/home/<user>` (fails) to working `/Users/<user>` — so it's only an improvement on hosts the role didn't work on before.