### PR TITLE
SA-071: LLM-wiki role — qmd installer, wiki-keeper agent, /wiki-* commands, scaffold playbook

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -10,6 +10,7 @@
     dev_tools_enabled: true
     bun_enabled: true
     claude_code_enabled: true
+    llm_wiki_enabled: true
     ssh_enabled: true
   roles:
     - role: base
@@ -28,5 +29,10 @@
       when: bun_enabled | bool
     - role: claude_code
       when: claude_code_enabled | bool
+    # llm_wiki after claude_code — shares the claude_npm_packages mechanism
+    # for qmd, and the claude_code role is responsible for merging
+    # files/mcp/qmd.json into ~/.claude.json before llm_wiki uses it.
+    - role: llm_wiki
+      when: llm_wiki_enabled | bool
     - role: ssh
       when: ssh_enabled | bool

--- a/roles/claude_code/defaults/main.yml
+++ b/roles/claude_code/defaults/main.yml
@@ -59,6 +59,14 @@ claude_custom_plugins:
 claude_npm_packages:
   - impeccable
   - sonarqube-mcp-server
+  # qmd: local markdown search (BM25 + vector + rerank) with bundled MCP
+  # server. Backs the llm_wiki role's /wiki-ingest, /wiki-query, /wiki-lint
+  # slash commands. MCP config lives in files/mcp/qmd.json.
+  # NOTE: The "qmd" name on npmjs is an abandoned 2016 stub — the real
+  # package is "@tobilu/qmd" (https://github.com/tobilu/qmd).
+  - "@tobilu/qmd"
+  # Uncomment to render wiki pages as slide decks:
+  # - "@marp-team/marp-cli"
 
 # ── MCP servers (merged into ~/.claude.json from files/mcp/*.json) ─────────
 # Drop .json files in files/mcp/ to add servers. See files/mcp/README.md.

--- a/roles/claude_code/files/CLAUDE.md
+++ b/roles/claude_code/files/CLAUDE.md
@@ -17,6 +17,13 @@ Agent teams are enabled. Use `claude --agent orchestrator` to start a continuous
 - Always read AGENTS.md and AI_INSTRUCTIONS.md in the project repo first
 - Prefer worktree isolation for implementation work
 
+## Persistent knowledge (LLM-wiki)
+
+- If a project has `docs/CLAUDE.md`, it is using the LLM-maintained wiki pattern. Read that schema first before writing to `docs/`.
+- Use `/wiki-ingest <path-or-url>` to file sources, `/wiki-query <question>` to search+synthesise, `/wiki-lint` to health-check.
+- The `wiki-keeper` subagent is the only agent that writes to the living zone. Other agents are read-only against the wiki.
+- Local search via `qmd` (npm `@tobilu/qmd`; MCP auto-registered). One-time per project: `qmd collection add docs/ && qmd embed`.
+
 ## Effort level
 
 `effortLevel` is pinned to `max` in `~/.claude/settings.json` and self-heals

--- a/roles/claude_code/files/agents/wiki-keeper.md
+++ b/roles/claude_code/files/agents/wiki-keeper.md
@@ -1,0 +1,46 @@
+---
+name: wiki-keeper
+description: Use this agent to ingest sources, query, or lint an LLM-maintained wiki. Trigger when the user drops material in `docs/sources/`, asks to ingest a file or URL, asks a research/synthesis question that likely already exists in the wiki, asks to file a result back, or asks to run a lint/health-check on the wiki. Reads the schema from `docs/CLAUDE.md` in the current project before acting. Writes only to LLM-maintained zones (`sources/`, `entities/`, `concepts/`, `decisions/`, `runbooks/`, `synthesis/`, `INDEX.md`, `LOG.md`); never touches governed-zone docs.
+tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch
+model: sonnet
+---
+
+You are the wiki-keeper — the only agent allowed to write to the LLM-maintained living zone of a project's wiki.
+
+## Workflow
+
+1. **Load the schema first.** Always `Read docs/CLAUDE.md` at the start of every turn. It tells you which subdirs are LLM-maintained vs governed, the frontmatter convention, the ingest/query/lint flows, and the naming rules. If there's no `docs/CLAUDE.md`, stop and tell the user the wiki isn't initialised.
+
+2. **Identify the operation** from the user's prompt:
+   - **Ingest** — a source was given (path, URL, drop in `docs/sources/`). Process it.
+   - **Query** — a question was asked. Search + synthesise.
+   - **Lint** — a health-check was requested. Report + fix with confirmation.
+   - **File-back** — a synthesis was produced and should be persisted.
+
+3. **For ingest:** Read source → discuss 3–5 key takeaways with the user → write `sources/<category>/YYYY-MM-DD-<slug>.md` with frontmatter + abstract + notes → update touched entities/concepts (create stubs for new ones, update `updated:` and flip contradicted sections to `status: stale`) → update `INDEX.md` → append `## [YYYY-MM-DD] ingest | <slug>` to `LOG.md` → report the delta.
+
+4. **For query:** Read `INDEX.md` to find candidates → read those pages → if qmd MCP is available (`mcp__qmd__*` tools visible), use it for wider hits → synthesise with citations → offer to file-back under `synthesis/YYYY-MM-DD-<slug>.md` → append to `LOG.md`.
+
+5. **For lint:** Check orphans, stale pages, contradictions, dangling wiki-links, missing-but-referenced concepts, INDEX drift, cross-zone drift. Produce a report; apply fixes on user confirmation (except INDEX drift, which is always safe to auto-fix). Append `## [YYYY-MM-DD] lint | <n issues>` to `LOG.md`.
+
+## Rules
+
+- **Never** write to governed-zone subdirs (`workflows/`, `process/`, `contracts/`, `Documentation/`, `governance/`, `plans/`, `compliance/`, `deployment/`, `architecture/`). If a claim in the living zone contradicts a governed doc, file a note in `synthesis/` and flag it to the user; do not edit the governed doc.
+- **Never** mutate files in `docs/sources/` after writing them. Sources are immutable; corrections go in entity/concept pages with `status: stale` on the obsolete section.
+- **Always** carry frontmatter on new pages. Use the shape in `docs/CLAUDE.md`.
+- **Always** cross-reference — new pages should list `related:` wiki-links; update related pages' `related:` in reverse.
+- **Prefer small diffs** — one ingest = many small updates across 5–15 pages, not one big rewrite of one page.
+- **Do not fabricate.** Every non-trivial claim must trace back to a source page (in `sources/`) or another sourced page. If you don't have a citation, mark the claim `status: draft` until it gains one.
+- **Keep sources short.** Summary abstracts are 1 paragraph, key takeaways 3–5 bullets. The full source can stay in `assets/` if it's a PDF; link to it rather than transcribing.
+
+## When qmd MCP is available
+
+Prefer `mcp__qmd__query` over walking the index for broad searches. Use plain `Read` + `Glob` for targeted lookups when you already know the path. Keep qmd indexes current: if a batch ingest touched many pages, suggest the user run `qmd embed docs/ --incremental` at the end of the session.
+
+## When the user asks something that's likely already in the wiki
+
+Before answering from scratch, run the query flow. If you find relevant pages, cite them. If the wiki is silent on the topic, tell the user and offer to ingest a source that would answer it.
+
+## Output shape
+
+After any operation, report: (a) what you did in 1–3 bullets, (b) the list of pages touched with relative paths, (c) next suggested step if any (e.g., "rerun `qmd embed docs/` since 11 pages were updated").

--- a/roles/claude_code/files/commands/wiki-ingest.md
+++ b/roles/claude_code/files/commands/wiki-ingest.md
@@ -1,0 +1,27 @@
+---
+description: File a new source into the LLM-maintained wiki — reads, summarises, updates entities/concepts, logs.
+argument-hint: <path-or-url>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, WebFetch, Agent
+---
+
+Ingest a new source into the project's wiki at `docs/`.
+
+**Source:** $ARGUMENTS
+
+## Flow
+
+1. Read `docs/CLAUDE.md` (the wiki schema) first. If it doesn't exist, stop and tell the user to initialise the wiki (`ansible-playbook roles/llm_wiki/tasks/scaffold_wiki.yml -e wiki_target=$(pwd)` from the dots repo).
+
+2. Delegate to the `wiki-keeper` subagent via the `Agent` tool with `subagent_type: wiki-keeper` and a prompt that:
+   - Includes the source path/URL from `$ARGUMENTS`.
+   - Tells it to run the **ingest** flow as defined in the schema.
+   - Requests a report of touched pages + a one-paragraph summary of what was learned.
+
+3. After wiki-keeper returns, summarise to the user what changed (pages touched, key takeaways, any stubs created) and suggest whether a `qmd embed docs/ --incremental` is worth running.
+
+## Notes
+
+- If `$ARGUMENTS` is a URL, wiki-keeper will fetch it first (via WebFetch), convert to markdown, then file.
+- If `$ARGUMENTS` is a local PDF, wiki-keeper will suggest running `pandoc <path> -o <path>.md` first if pandoc is installed; otherwise it reads the PDF directly via the `Read` tool and saves a markdown summary alongside.
+- A single ingest touches 5–15 pages. Don't be surprised.
+- Sources are **immutable** once filed — corrections go into entity/concept pages, not into the source.

--- a/roles/claude_code/files/commands/wiki-ingest.md
+++ b/roles/claude_code/files/commands/wiki-ingest.md
@@ -10,7 +10,7 @@ Ingest a new source into the project's wiki at `docs/`.
 
 ## Flow
 
-1. Read `docs/CLAUDE.md` (the wiki schema) first. If it doesn't exist, stop and tell the user to initialise the wiki (`ansible-playbook roles/llm_wiki/tasks/scaffold_wiki.yml -e wiki_target=$(pwd)` from the dots repo).
+1. Read `docs/CLAUDE.md` (the wiki schema) first. If it doesn't exist, stop and tell the user to initialise the wiki (from the dots repo root: `ansible-playbook scaffold-wiki.yml -e "wiki_target=$(pwd)"`).
 
 2. Delegate to the `wiki-keeper` subagent via the `Agent` tool with `subagent_type: wiki-keeper` and a prompt that:
    - Includes the source path/URL from `$ARGUMENTS`.

--- a/roles/claude_code/files/commands/wiki-lint.md
+++ b/roles/claude_code/files/commands/wiki-lint.md
@@ -1,0 +1,28 @@
+---
+description: Health-check the LLM-maintained wiki — flags orphans, stale pages, contradictions, dangling wiki-links, missing pages, and INDEX drift.
+argument-hint: [--apply]
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent
+---
+
+Run a lint/health-check over the project's wiki at `docs/`.
+
+**Args:** $ARGUMENTS (pass `--apply` to auto-apply safe fixes; default is report-only)
+
+## Flow
+
+1. Read `docs/CLAUDE.md` (schema). If it doesn't exist, stop.
+
+2. Delegate to the `wiki-keeper` subagent via the `Agent` tool with `subagent_type: wiki-keeper` and a prompt that:
+   - Tells it to run the **lint** flow as defined in the schema.
+   - Lists the checks required: orphans, stale, contradictions, dangling wiki-links, missing-but-referenced concepts, INDEX drift, cross-zone drift.
+   - If `$ARGUMENTS` contains `--apply`, tells it to auto-apply safe fixes (INDEX drift is always safe). Otherwise, report only.
+
+3. Present the lint report with severity (info / warn / error) and grouped by check type.
+
+4. For warn/error items, ask the user which to fix. Wiki-keeper applies confirmed fixes, appends `## [YYYY-MM-DD] lint | <n issues, <m fixes>` to `LOG.md`, and reports deltas.
+
+## Notes
+
+- Run weekly, or schedule via claudeclaw heartbeat.
+- After a big ingest pass (3+ sources in a day), run lint immediately — ingest stubs are likely orphan until cross-references catch up.
+- Cross-zone drift (living-zone claim contradicts a governed-zone doc) is **never** auto-fixed. Wiki-keeper will flag and propose a synthesis note; the human decides which source is authoritative.

--- a/roles/claude_code/files/commands/wiki-query.md
+++ b/roles/claude_code/files/commands/wiki-query.md
@@ -1,0 +1,30 @@
+---
+description: Answer a question from the LLM-maintained wiki with citations; optionally file the answer back so the synthesis compounds.
+argument-hint: <question>
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Agent, mcp__qmd__query, mcp__qmd__status
+---
+
+Query the project's wiki at `docs/` for a question and synthesise an answer.
+
+**Question:** $ARGUMENTS
+
+## Flow
+
+1. Read `docs/CLAUDE.md` (the schema) and `docs/INDEX.md` (the catalog). If neither exists, stop and tell the user the wiki isn't initialised.
+
+2. Delegate to the `wiki-keeper` subagent via the `Agent` tool with `subagent_type: wiki-keeper` and a prompt that:
+   - Includes the question from `$ARGUMENTS`.
+   - Tells it to run the **query** flow as defined in the schema.
+   - Asks it to use qmd MCP (`mcp__qmd__query`) if the candidate set from INDEX lookup is thin.
+   - Requests a synthesised answer with citations (wiki-link references to the pages it drew from).
+   - Asks whether the answer is substantive enough to file back to `synthesis/`.
+
+3. Present the answer with citations. If wiki-keeper recommends file-back, ask the user to confirm before creating the synthesis page.
+
+4. If the user confirms file-back, wiki-keeper writes `synthesis/YYYY-MM-DD-<slug>.md`, updates INDEX, appends to LOG, and updates `related:` frontmatter on source pages.
+
+## Notes
+
+- Citation format: inline `[[entities/vendor-openai]]`, `[[concepts/model-tier-contract]]`, or `see docs/contracts/model-tier-contract.md` for governed-zone refs.
+- If the wiki is silent on the topic, wiki-keeper will tell you so and may suggest a source to ingest. Do not fabricate answers — silence is a signal.
+- qmd indexes might be stale. If the query result set feels thin and the LOG shows recent ingests, suggest `qmd embed docs/ --incremental` first.

--- a/roles/claude_code/files/mcp/README.md
+++ b/roles/claude_code/files/mcp/README.md
@@ -37,3 +37,4 @@ Delete the `.json` file and re-run the playbook.
 ## Currently Configured
 
 - `sonarqube.json` — SonarCloud/SonarQube code analysis (requires SONARQUBE_TOKEN)
+- `qmd.json` — local markdown search (hybrid BM25 + vector + rerank) over project `docs/`. Companion to the LLM-wiki pattern (see `roles/llm_wiki/`). npm package `@tobilu/qmd`; binary `qmd` on PATH. MCP: `qmd mcp` (stdio). One-time per project: `qmd collection add docs/ && qmd embed`.

--- a/roles/claude_code/files/mcp/qmd.json
+++ b/roles/claude_code/files/mcp/qmd.json
@@ -1,0 +1,7 @@
+{
+  "qmd": {
+    "command": "qmd",
+    "args": ["mcp"],
+    "env": {}
+  }
+}

--- a/roles/claude_code/files/skills/wiki-maintenance/SKILL.md
+++ b/roles/claude_code/files/skills/wiki-maintenance/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: wiki-maintenance
+description: Use this skill whenever the user asks to ingest a source, file material into the wiki, search/query the wiki, run a wiki lint/health check, or drops content into a project's `docs/sources/` directory. Triggers include "ingest this", "add to wiki", "file this under", "search the wiki", "check the wiki", "wiki lint", "process these sources", "file this back", "what does the wiki say about", "has anyone looked into". Explains the LLM-maintained wiki pattern, the three slash commands (`/wiki-ingest`, `/wiki-query`, `/wiki-lint`), the wiki-keeper subagent, and the qmd search tool.
+---
+
+# Wiki Maintenance Skill
+
+This project uses the **LLM-maintained wiki pattern**: raw sources → LLM-curated markdown → compounding synthesis. Knowledge accumulates rather than being rediscovered every query.
+
+## Check first
+
+Before doing anything, verify the project has a wiki by checking for `docs/CLAUDE.md`:
+
+```bash
+test -f docs/CLAUDE.md && echo "wiki initialised" || echo "wiki not initialised — run scaffold"
+```
+
+If not initialised:
+
+```bash
+# From the dots repo
+ansible-playbook roles/llm_wiki/tasks/scaffold_wiki.yml \
+  -e "wiki_target=$(pwd)"
+```
+
+That scaffolds the schema, INDEX, LOG, and living-zone subdirs into `docs/`.
+
+## Operations
+
+Three slash commands cover everything:
+
+- **`/wiki-ingest <path-or-url>`** — file a new source. Reads, summarises, updates entities/concepts, logs.
+- **`/wiki-query <question>`** — answer from the wiki with citations; optionally file back to `synthesis/`.
+- **`/wiki-lint`** — orphans, stale, contradictions, dangling links, INDEX drift.
+
+Each command delegates to the `wiki-keeper` subagent (see `~/.claude/agents/wiki-keeper.md`) — the only agent that writes to the living zone.
+
+## Zones (read `docs/CLAUDE.md` for details)
+
+- **Living zone** (LLM-maintained): `sources/`, `entities/`, `concepts/`, `decisions/`, `runbooks/`, `synthesis/`, `INDEX.md`, `LOG.md`.
+- **Governed zone** (human-owned, read-only to wiki-keeper): `workflows/`, `process/`, `contracts/`, `Documentation/`, `governance/`, `plans/`, `compliance/`, `deployment/`, `architecture/`.
+
+Queries may cite governed pages. Ingests may reference them. Lint flags cross-zone drift but does not auto-fix governed content.
+
+## Tooling
+
+- **qmd** (local BM25/vector/rerank markdown search — npm package `@tobilu/qmd`) is installed via dots and MCP-registered. One-time setup in the project: `qmd collection add docs/ && qmd embed`. Claude uses `mcp__qmd__query` transparently.
+- **Obsidian** (optional) as a GUI reader — open the repo as a vault, `[[wiki-links]]` resolve natively, graph view shows entity clusters.
+- **Obsidian Web Clipper** — clip articles to `docs/sources/clippings/` as markdown, then `/wiki-ingest` them.
+- **Marp CLI** (optional, `@marp-team/marp-cli` in `claude_npm_packages`) — render wiki pages as slide decks.
+- **Pandoc** (optional) — convert PDFs/DOCX → markdown for ingest.
+
+## When to ingest
+
+Ingest material that has lasting value: research papers, vendor docs, customer interviews, postmortems, competitive briefs, meeting notes with durable decisions. **Don't** ingest transient material — PR comments, debugging sessions, one-off slack pings. Those belong in git history or chat.
+
+## When to query
+
+Before re-deriving an answer to a cross-repo or research question, query first. If the wiki has it, cite. If not, you save re-deriving time only on the next question.
+
+## When to lint
+
+Weekly (scheduled via claudeclaw) or immediately after a batch ingest of 3+ sources. Lint surfaces the drift before it compounds.
+
+## Anti-patterns
+
+- Hand-editing living-zone pages without routing through wiki-keeper → INDEX/frontmatter drift.
+- Using the wiki as a task tracker → tasks live in the project's issue tracker. Wiki is for synthesis.
+- Ingesting everything → wiki noise. Curate hard.
+- Writing synthesis directly instead of asking wiki-keeper to file back → skips cross-reference updates.
+
+## Further reading
+
+- Project schema: `docs/CLAUDE.md`
+- Workflow guide: `docs/workflows/llm-wiki.md` (if the project includes it)
+- Agent spec: `~/.claude/agents/wiki-keeper.md`

--- a/roles/claude_code/files/skills/wiki-maintenance/SKILL.md
+++ b/roles/claude_code/files/skills/wiki-maintenance/SKILL.md
@@ -18,8 +18,8 @@ test -f docs/CLAUDE.md && echo "wiki initialised" || echo "wiki not initialised 
 If not initialised:
 
 ```bash
-# From the dots repo
-ansible-playbook roles/llm_wiki/tasks/scaffold_wiki.yml \
+# From the dots repo root
+ansible-playbook scaffold-wiki.yml \
   -e "wiki_target=$(pwd)"
 ```
 

--- a/roles/llm_wiki/defaults/main.yml
+++ b/roles/llm_wiki/defaults/main.yml
@@ -18,10 +18,11 @@
 llm_wiki_enabled: true
 
 # qmd: local markdown search (BM25 + vector + rerank) with MCP server.
-# https://github.com/tobi/qmd — installed via npm globally.
-# Piggybacks on roles/claude_code/ claude_npm_packages, so this flag is
-# informational unless you want to force reinstall.
-install_qmd: true
+# https://github.com/tobilu/qmd — installed via npm (@tobilu/qmd) globally.
+# Default OFF here because claude_code role's claude_npm_packages already
+# installs @tobilu/qmd. Flip to true to force a reinstall/upgrade in
+# isolation, e.g. when running --tags llm_wiki without --tags claude_code.
+install_qmd: false
 
 # Optional extras. Default off — flip per-host or via --extra-vars.
 install_marp: false      # @marp-team/marp-cli — render wiki pages as slides

--- a/roles/llm_wiki/defaults/main.yml
+++ b/roles/llm_wiki/defaults/main.yml
@@ -1,0 +1,36 @@
+---
+# roles/llm_wiki - Install tooling for the LLM-maintained wiki pattern
+# and optionally scaffold the wiki structure into a target repo.
+#
+# The pattern itself (agent, slash commands, skill, qmd MCP) is deployed
+# globally by roles/claude_code/. This role adds:
+#   - qmd install (opt in/out)
+#   - optional marp-cli / pandoc for source conversion
+#   - a scaffold step that creates the wiki structure in a target repo
+#
+# Usage:
+#   # Just install tools (default in dev.yml):
+#   ansible-playbook dev.yml --tags llm_wiki
+#
+#   # Scaffold the wiki into a specific repo:
+#   ansible-playbook scaffold-wiki.yml -e "wiki_target=/abs/path/to/repo"
+
+llm_wiki_enabled: true
+
+# qmd: local markdown search (BM25 + vector + rerank) with MCP server.
+# https://github.com/tobi/qmd — installed via npm globally.
+# Piggybacks on roles/claude_code/ claude_npm_packages, so this flag is
+# informational unless you want to force reinstall.
+install_qmd: true
+
+# Optional extras. Default off — flip per-host or via --extra-vars.
+install_marp: false      # @marp-team/marp-cli — render wiki pages as slides
+install_pandoc: false    # pandoc — convert PDFs/DOCX to markdown for ingest
+
+# Scaffold behaviour. Default off — scaffold is opt-in via a separate
+# top-level playbook (scaffold-wiki.yml) so routine dev.yml runs don't
+# touch target repos.
+scaffold_wiki: false
+wiki_target: ""          # absolute path to the repo root to scaffold into
+wiki_dir: "docs"         # directory inside wiki_target that holds the wiki
+wiki_project_name: "{{ wiki_target | basename }}"

--- a/roles/llm_wiki/tasks/install_optional_tools.yml
+++ b/roles/llm_wiki/tasks/install_optional_tools.yml
@@ -1,0 +1,32 @@
+---
+# Optional tools that help with the ingest/output side of the wiki.
+# All flags default off — opt in per-host.
+
+# ── marp-cli: render wiki pages as slide decks ──────────────────────────────
+- name: "llm_wiki | install @marp-team/marp-cli via npm (global)"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  community.general.npm:
+    name: "@marp-team/marp-cli"
+    global: true
+    state: latest
+  when: install_marp | bool
+
+# ── pandoc: convert PDF/DOCX to markdown before ingest ──────────────────────
+- name: "[macOS] llm_wiki | install pandoc via Homebrew"
+  community.general.homebrew:
+    name: pandoc
+    state: present
+  when:
+    - install_pandoc | bool
+    - ansible_facts['os_family'] == "Darwin"
+
+- name: "[Linux] llm_wiki | install pandoc via apt"
+  become: true
+  ansible.builtin.apt:
+    name: pandoc
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+  when:
+    - install_pandoc | bool
+    - ansible_facts['os_family'] == "Debian"

--- a/roles/llm_wiki/tasks/install_optional_tools.yml
+++ b/roles/llm_wiki/tasks/install_optional_tools.yml
@@ -3,7 +3,7 @@
 # All flags default off — opt in per-host.
 
 # ── marp-cli: render wiki pages as slide decks ──────────────────────────────
-- name: "llm_wiki | install @marp-team/marp-cli via npm (global)"
+- name: "LLM Wiki | Install @marp-team/marp-cli via npm (global)"
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   community.general.npm:
     name: "@marp-team/marp-cli"
@@ -12,7 +12,7 @@
   when: install_marp | bool
 
 # ── pandoc: convert PDF/DOCX to markdown before ingest ──────────────────────
-- name: "[macOS] llm_wiki | install pandoc via Homebrew"
+- name: "[macOS] LLM Wiki | Install pandoc via Homebrew"
   community.general.homebrew:
     name: pandoc
     state: present
@@ -20,7 +20,7 @@
     - install_pandoc | bool
     - ansible_facts['os_family'] == "Darwin"
 
-- name: "[Linux] llm_wiki | install pandoc via apt"
+- name: "[Linux] LLM Wiki | Install pandoc via apt"
   become: true
   ansible.builtin.apt:
     name: pandoc

--- a/roles/llm_wiki/tasks/install_qmd.yml
+++ b/roles/llm_wiki/tasks/install_qmd.yml
@@ -9,14 +9,14 @@
 # roles/claude_code/files/mcp/qmd.json and is merged into ~/.claude.json
 # by the claude_code role — not duplicated here.
 
-- name: "llm_wiki | check if qmd is already installed"
+- name: "LLM Wiki | Check if qmd is already installed"
   ansible.builtin.command: qmd --version
   register: qmd_version_check
   changed_when: false
   failed_when: false
   check_mode: false
 
-- name: "llm_wiki | install qmd via npm (global) — @tobilu/qmd"
+- name: "LLM Wiki | Install qmd via npm (global) — @tobilu/qmd"
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   community.general.npm:
     name: "@tobilu/qmd"
@@ -25,7 +25,7 @@
   when: qmd_version_check.rc != 0 or qmd_version_check.stdout == ''
   register: qmd_install
 
-- name: "llm_wiki | qmd install summary"
+- name: "LLM Wiki | Qmd install summary"
   ansible.builtin.debug:
     msg: >-
       qmd {{ 'already installed at version ' + qmd_version_check.stdout

--- a/roles/llm_wiki/tasks/install_qmd.yml
+++ b/roles/llm_wiki/tasks/install_qmd.yml
@@ -1,0 +1,34 @@
+---
+# Install qmd globally via npm. Works on macOS and Linux.
+#
+# qmd is a Node/Bun package; it bundles its own MCP server (`qmd mcp`).
+# Note: the npm name is "@tobilu/qmd" — the unscoped "qmd" package on
+# npmjs is an abandoned 2016 stub. The real source is
+# https://github.com/tobilu/qmd. The binary lands as `qmd` on PATH.
+# The MCP registration for Claude Code lives in
+# roles/claude_code/files/mcp/qmd.json and is merged into ~/.claude.json
+# by the claude_code role — not duplicated here.
+
+- name: "llm_wiki | check if qmd is already installed"
+  ansible.builtin.command: qmd --version
+  register: qmd_version_check
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+- name: "llm_wiki | install qmd via npm (global) — @tobilu/qmd"
+  become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
+  community.general.npm:
+    name: "@tobilu/qmd"
+    global: true
+    state: latest
+  when: qmd_version_check.rc != 0 or qmd_version_check.stdout == ''
+  register: qmd_install
+
+- name: "llm_wiki | qmd install summary"
+  ansible.builtin.debug:
+    msg: >-
+      qmd {{ 'already installed at version ' + qmd_version_check.stdout
+         if qmd_version_check.rc == 0 and qmd_version_check.stdout != ''
+         else 'installed via npm (@tobilu/qmd)' }}.
+      Per-project setup: `qmd collection add docs/ && qmd embed` inside each wiki repo.

--- a/roles/llm_wiki/tasks/install_qmd.yml
+++ b/roles/llm_wiki/tasks/install_qmd.yml
@@ -1,34 +1,27 @@
 ---
-# Install qmd globally via npm. Works on macOS and Linux.
+# Install @tobilu/qmd globally via npm.
 #
-# qmd is a Node/Bun package; it bundles its own MCP server (`qmd mcp`).
-# Note: the npm name is "@tobilu/qmd" — the unscoped "qmd" package on
-# npmjs is an abandoned 2016 stub. The real source is
-# https://github.com/tobilu/qmd. The binary lands as `qmd` on PATH.
+# Default path: this task is gated by install_qmd (defaults to FALSE in
+# defaults/main.yml) because roles/claude_code/ already installs
+# @tobilu/qmd via claude_npm_packages. Flip install_qmd=true to force a
+# dedicated install, e.g. when running --tags llm_wiki in isolation.
+#
+# https://github.com/tobilu/qmd — the unscoped "qmd" package on npmjs is
+# an abandoned 2016 stub. Binary lands as `qmd` on PATH after install.
 # The MCP registration for Claude Code lives in
 # roles/claude_code/files/mcp/qmd.json and is merged into ~/.claude.json
 # by the claude_code role — not duplicated here.
 
-- name: "LLM Wiki | Check if qmd is already installed"
-  ansible.builtin.command: qmd --version
-  register: qmd_version_check
-  changed_when: false
-  failed_when: false
-  check_mode: false
-
-- name: "LLM Wiki | Install qmd via npm (global) — @tobilu/qmd"
+- name: "LLM Wiki | Install @tobilu/qmd via npm (global)"
   become: "{{ ansible_facts['os_family'] != 'Darwin' }}"
   community.general.npm:
     name: "@tobilu/qmd"
     global: true
-    state: latest
-  when: qmd_version_check.rc != 0 or qmd_version_check.stdout == ''
+    state: present
   register: qmd_install
 
 - name: "LLM Wiki | Qmd install summary"
   ansible.builtin.debug:
     msg: >-
-      qmd {{ 'already installed at version ' + qmd_version_check.stdout
-         if qmd_version_check.rc == 0 and qmd_version_check.stdout != ''
-         else 'installed via npm (@tobilu/qmd)' }}.
-      Per-project setup: `qmd collection add docs/ && qmd embed` inside each wiki repo.
+      @tobilu/qmd {{ 'installed' if qmd_install is changed else 'already present' }}.
+      Per-project setup: `qmd collection add docs/ && qmd embed`.

--- a/roles/llm_wiki/tasks/main.yml
+++ b/roles/llm_wiki/tasks/main.yml
@@ -2,19 +2,19 @@
 # Orchestrator for the llm_wiki role.
 # Gate everything on llm_wiki_enabled so the role can be skipped cleanly.
 
-- name: "llm_wiki | install qmd"
+- name: "LLM Wiki | Install qmd"
   ansible.builtin.include_tasks: install_qmd.yml
   when:
     - llm_wiki_enabled | bool
     - install_qmd | bool
   tags: [llm_wiki, llm_wiki_install]
 
-- name: "llm_wiki | install optional tools (marp, pandoc)"
+- name: "LLM Wiki | Install optional tools (marp, pandoc)"
   ansible.builtin.include_tasks: install_optional_tools.yml
   when: llm_wiki_enabled | bool
   tags: [llm_wiki, llm_wiki_install]
 
-- name: "llm_wiki | scaffold wiki structure into target repo"
+- name: "LLM Wiki | Scaffold wiki structure into target repo"
   ansible.builtin.include_tasks: scaffold.yml
   when:
     - llm_wiki_enabled | bool

--- a/roles/llm_wiki/tasks/main.yml
+++ b/roles/llm_wiki/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+# Orchestrator for the llm_wiki role.
+# Gate everything on llm_wiki_enabled so the role can be skipped cleanly.
+
+- name: "llm_wiki | install qmd"
+  ansible.builtin.include_tasks: install_qmd.yml
+  when:
+    - llm_wiki_enabled | bool
+    - install_qmd | bool
+  tags: [llm_wiki, llm_wiki_install]
+
+- name: "llm_wiki | install optional tools (marp, pandoc)"
+  ansible.builtin.include_tasks: install_optional_tools.yml
+  when: llm_wiki_enabled | bool
+  tags: [llm_wiki, llm_wiki_install]
+
+- name: "llm_wiki | scaffold wiki structure into target repo"
+  ansible.builtin.include_tasks: scaffold.yml
+  when:
+    - llm_wiki_enabled | bool
+    - scaffold_wiki | bool
+  tags: [llm_wiki, llm_wiki_scaffold]

--- a/roles/llm_wiki/tasks/scaffold.yml
+++ b/roles/llm_wiki/tasks/scaffold.yml
@@ -3,7 +3,7 @@
 # Idempotent — never overwrites existing files (force: false by default on
 # copy/template).
 
-- name: "llm_wiki scaffold | validate wiki_target is absolute and exists"
+- name: "LLM Wiki scaffold | Validate wiki_target is absolute and exists"
   ansible.builtin.assert:
     that:
       - wiki_target | length > 0
@@ -12,19 +12,19 @@
       wiki_target must be an absolute path. Got: "{{ wiki_target }}".
       Example: -e "wiki_target=/Users/you/Playground/some-repo"
 
-- name: "llm_wiki scaffold | ensure wiki_target exists"
+- name: "LLM Wiki scaffold | Ensure wiki_target exists"
   ansible.builtin.stat:
     path: "{{ wiki_target }}"
   register: wiki_target_stat
 
-- name: "llm_wiki scaffold | fail if wiki_target doesn't exist"
+- name: "LLM Wiki scaffold | Fail if wiki_target doesn't exist"
   ansible.builtin.assert:
     that:
       - wiki_target_stat.stat.exists
       - wiki_target_stat.stat.isdir
     fail_msg: "wiki_target {{ wiki_target }} does not exist or is not a directory."
 
-- name: "llm_wiki scaffold | create living-zone directory structure"
+- name: "LLM Wiki scaffold | Create living-zone directory structure"
   ansible.builtin.file:
     path: "{{ wiki_target }}/{{ wiki_dir }}/{{ item }}"
     state: directory
@@ -42,7 +42,7 @@
     - synthesis
     - templates
 
-- name: "llm_wiki scaffold | drop .gitkeep in empty subdirs"
+- name: "LLM Wiki scaffold | Drop .gitkeep in empty subdirs"
   ansible.builtin.copy:
     content: ""
     dest: "{{ wiki_target }}/{{ wiki_dir }}/{{ item }}/.gitkeep"
@@ -58,42 +58,42 @@
     - decisions
     - runbooks
 
-- name: "llm_wiki scaffold | render schema (CLAUDE.md) if missing"
+- name: "LLM Wiki scaffold | Render schema (CLAUDE.md) if missing"
   ansible.builtin.template:
     src: CLAUDE.md.j2
     dest: "{{ wiki_target }}/{{ wiki_dir }}/CLAUDE.md"
     mode: "0644"
     force: false
 
-- name: "llm_wiki scaffold | render INDEX.md if missing"
+- name: "LLM Wiki scaffold | Render INDEX.md if missing"
   ansible.builtin.template:
     src: INDEX.md.j2
     dest: "{{ wiki_target }}/{{ wiki_dir }}/INDEX.md"
     mode: "0644"
     force: false
 
-- name: "llm_wiki scaffold | render LOG.md if missing"
+- name: "LLM Wiki scaffold | Render LOG.md if missing"
   ansible.builtin.template:
     src: LOG.md.j2
     dest: "{{ wiki_target }}/{{ wiki_dir }}/LOG.md"
     mode: "0644"
     force: false
 
-- name: "llm_wiki scaffold | render sources/README if missing"
+- name: "LLM Wiki scaffold | Render sources/README if missing"
   ansible.builtin.template:
     src: README-sources.md.j2
     dest: "{{ wiki_target }}/{{ wiki_dir }}/sources/README.md"
     mode: "0644"
     force: false
 
-- name: "llm_wiki scaffold | render synthesis/README if missing"
+- name: "LLM Wiki scaffold | Render synthesis/README if missing"
   ansible.builtin.template:
     src: README-synthesis.md.j2
     dest: "{{ wiki_target }}/{{ wiki_dir }}/synthesis/README.md"
     mode: "0644"
     force: false
 
-- name: "llm_wiki scaffold | copy page templates (entity/concept/decision/runbook/source)"
+- name: "LLM Wiki scaffold | Copy page templates (entity/concept/decision/runbook/source)"
   ansible.builtin.copy:
     src: "{{ item }}"
     dest: "{{ wiki_target }}/{{ wiki_dir }}/templates/{{ item | basename | regex_replace('\\.j2$', '') }}"
@@ -101,7 +101,7 @@
     force: false
   loop: "{{ query('fileglob', role_path + '/templates/*-template.md.j2') }}"
 
-- name: "llm_wiki scaffold | summary"
+- name: "LLM Wiki scaffold | Summary"
   ansible.builtin.debug:
     msg: |
       Wiki scaffolded at {{ wiki_target }}/{{ wiki_dir }}/.

--- a/roles/llm_wiki/tasks/scaffold.yml
+++ b/roles/llm_wiki/tasks/scaffold.yml
@@ -1,0 +1,116 @@
+---
+# Scaffold the LLM-wiki structure into a target repo.
+# Idempotent — never overwrites existing files (force: false by default on
+# copy/template).
+
+- name: "llm_wiki scaffold | validate wiki_target is absolute and exists"
+  ansible.builtin.assert:
+    that:
+      - wiki_target | length > 0
+      - wiki_target is match("^/")
+    fail_msg: >-
+      wiki_target must be an absolute path. Got: "{{ wiki_target }}".
+      Example: -e "wiki_target=/Users/you/Playground/some-repo"
+
+- name: "llm_wiki scaffold | ensure wiki_target exists"
+  ansible.builtin.stat:
+    path: "{{ wiki_target }}"
+  register: wiki_target_stat
+
+- name: "llm_wiki scaffold | fail if wiki_target doesn't exist"
+  ansible.builtin.assert:
+    that:
+      - wiki_target_stat.stat.exists
+      - wiki_target_stat.stat.isdir
+    fail_msg: "wiki_target {{ wiki_target }} does not exist or is not a directory."
+
+- name: "llm_wiki scaffold | create living-zone directory structure"
+  ansible.builtin.file:
+    path: "{{ wiki_target }}/{{ wiki_dir }}/{{ item }}"
+    state: directory
+    mode: "0755"
+  loop:
+    - sources
+    - sources/clippings
+    - sources/transcripts
+    - sources/papers
+    - sources/assets
+    - entities
+    - concepts
+    - decisions
+    - runbooks
+    - synthesis
+    - templates
+
+- name: "llm_wiki scaffold | drop .gitkeep in empty subdirs"
+  ansible.builtin.copy:
+    content: ""
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/{{ item }}/.gitkeep"
+    mode: "0644"
+    force: false
+  loop:
+    - sources/clippings
+    - sources/transcripts
+    - sources/papers
+    - sources/assets
+    - entities
+    - concepts
+    - decisions
+    - runbooks
+
+- name: "llm_wiki scaffold | render schema (CLAUDE.md) if missing"
+  ansible.builtin.template:
+    src: CLAUDE.md.j2
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/CLAUDE.md"
+    mode: "0644"
+    force: false
+
+- name: "llm_wiki scaffold | render INDEX.md if missing"
+  ansible.builtin.template:
+    src: INDEX.md.j2
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/INDEX.md"
+    mode: "0644"
+    force: false
+
+- name: "llm_wiki scaffold | render LOG.md if missing"
+  ansible.builtin.template:
+    src: LOG.md.j2
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/LOG.md"
+    mode: "0644"
+    force: false
+
+- name: "llm_wiki scaffold | render sources/README if missing"
+  ansible.builtin.template:
+    src: README-sources.md.j2
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/sources/README.md"
+    mode: "0644"
+    force: false
+
+- name: "llm_wiki scaffold | render synthesis/README if missing"
+  ansible.builtin.template:
+    src: README-synthesis.md.j2
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/synthesis/README.md"
+    mode: "0644"
+    force: false
+
+- name: "llm_wiki scaffold | copy page templates (entity/concept/decision/runbook/source)"
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: "{{ wiki_target }}/{{ wiki_dir }}/templates/{{ item | basename | regex_replace('\\.j2$', '') }}"
+    mode: "0644"
+    force: false
+  loop: "{{ query('fileglob', role_path + '/templates/*-template.md.j2') }}"
+
+- name: "llm_wiki scaffold | summary"
+  ansible.builtin.debug:
+    msg: |
+      Wiki scaffolded at {{ wiki_target }}/{{ wiki_dir }}/.
+
+      Next steps:
+        cd {{ wiki_target }}
+        qmd collection add {{ wiki_dir }}/ && qmd embed
+        open Claude Code; try /wiki-ingest <some-source> or /wiki-query <some-question>
+
+      Schema: {{ wiki_target }}/{{ wiki_dir }}/CLAUDE.md
+      Catalog: {{ wiki_target }}/{{ wiki_dir }}/INDEX.md
+      Templates: {{ wiki_target }}/{{ wiki_dir }}/templates/

--- a/roles/llm_wiki/templates/CLAUDE.md.j2
+++ b/roles/llm_wiki/templates/CLAUDE.md.j2
@@ -1,0 +1,107 @@
+# {{ wiki_project_name }} Wiki Schema
+
+This file is the instruction sheet for the **LLM-maintained wiki** layered onto `{{ wiki_dir }}/`. Claude Code loads this automatically when working in `{{ wiki_dir }}/`. Read it before ingesting sources, answering wiki queries, or running lint.
+
+The pattern: raw sources → LLM-curated synthesis → index + log for navigation. Knowledge accumulates; it is not re-derived on every question.
+
+Reference: [LLM Wiki pattern](https://gist.github.com/prashantsolanki3/baf5332058a11527489d96fca3ac93c0) — this schema is an instantiation of that pattern.
+
+## Zones
+
+Two kinds of subdirectories under `{{ wiki_dir }}/`. The wiki-keeper writes only to the living zone.
+
+### Living zone (LLM-maintained by `wiki-keeper`)
+
+| Dir | Holds |
+|---|---|
+| `sources/` | Raw ingested material: clippings, transcripts, papers, assets. Immutable once dropped. Wiki-keeper **reads** but never rewrites. |
+| `entities/` | Recurring nouns: repos, services, agents, people, vendors, customers. One page per entity. |
+| `concepts/` | Recurring ideas: design patterns, architectural concepts, principles. |
+| `decisions/` | Lightweight ADRs — dated records of a decision, context, and consequences. |
+| `runbooks/` | Ops recipes: verify suites, bootstrap flows, incident response, deploy procedures. |
+| `synthesis/` | Filed-back query results, comparisons, analyses. |
+| `INDEX.md` | Catalog of every page with one-line summary, organised by category. |
+| `LOG.md` | Chronological record of every ingest/query/lint/filed-back operation. Append-only. |
+| `templates/` | Page shells copied when creating a new entity/concept/decision/runbook manually. |
+| `CLAUDE.md` | This file. |
+
+### Governed zone (human-owned — wiki-keeper reads, never writes)
+
+Any subdirectory of `{{ wiki_dir }}/` not listed in the living-zone table above is considered governed. Typical governed dirs include `workflows/`, `process/`, `contracts/`, `governance/`, formal product documentation, and `plans/`. The wiki-keeper reads these freely and may cite them, but does not edit them. Drift between the two zones is flagged by lint but never auto-fixed.
+
+## Page frontmatter
+
+Every page in the living zone starts with YAML frontmatter:
+
+```yaml
+---
+name: Concise page title
+type: entity | concept | decision | runbook | source | synthesis
+tags: [tag1, tag2]
+sources: [sources/clippings/YYYY-MM-DD-...md, sources/papers/...md]
+related: [[entities/foo]], [[concepts/bar]]
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: stub | draft | current | stale
+---
+```
+
+- `sources` is the provenance list — every non-trivial claim should be traceable.
+- `related` uses `[[path/without-extension]]` wiki-link syntax; Obsidian and qmd both parse it.
+- `status`: **stub** (placeholder), **draft** (in progress), **current** (verified against latest sources), **stale** (last-updated predates a contradicting source — flagged by lint).
+
+## Operations
+
+### Ingest — `/wiki-ingest <path-or-url>`
+
+1. Wiki-keeper reads the source end-to-end (fetch URL or extract PDF if needed).
+2. Discusses 3–5 key takeaways with the user.
+3. Writes `sources/<category>/YYYY-MM-DD-<slug>.md` with frontmatter + abstract + structured notes.
+4. For each touched entity/concept: **update** existing pages (note contradictions, flip stale sections, bump `updated:`) or **create** stubs for new ones.
+5. Updates `INDEX.md`.
+6. Appends to `LOG.md`: `## [YYYY-MM-DD] ingest | <slug>`.
+7. Reports the delta to the user.
+
+### Query — `/wiki-query <question>`
+
+1. Reads `INDEX.md` to find candidates.
+2. Reads those pages.
+3. If qmd MCP is available, uses it for wider hits.
+4. Synthesises with citations.
+5. Offers to file back under `synthesis/YYYY-MM-DD-<slug>.md` if substantive.
+6. Appends to `LOG.md`.
+
+### Lint — `/wiki-lint`
+
+Checks: orphans, stale, contradictions, dangling wiki-links, missing pages, INDEX drift, cross-zone drift.
+
+Report → user confirms → wiki-keeper applies fixes. INDEX drift auto-fixes (safe). Cross-zone drift is never auto-fixed — wiki-keeper files a synthesis note and flags to the user.
+
+## Wiki-keeper subagent
+
+Specialist agent at `~/.claude/agents/wiki-keeper.md` (deployed by dots). Invoke via the `Agent` tool with `subagent_type: wiki-keeper`. Other agents are **read-only** against the living zone.
+
+## Tooling
+
+- **qmd** — local markdown search (npm package `@tobilu/qmd`, binary `qmd`). Install via dots (`roles/claude_code/` `claude_npm_packages`). MCP auto-registered. One-time per project: `qmd collection add {{ wiki_dir }}/ && qmd embed`. Re-embed after batch ingests with `qmd embed --incremental`.
+- **Obsidian** — optional reader. Open this repo as a vault. Configure attachment path to `{{ wiki_dir }}/sources/assets/`. Web Clipper output → `{{ wiki_dir }}/sources/clippings/`.
+- **Marp CLI** — optional slide rendering.
+- **Pandoc** — optional PDF/DOCX → markdown conversion.
+
+## Naming conventions
+
+- Entities: `entities/<kind>-<slug>.md` — e.g. `repo-foo`, `vendor-bar`, `agent-baz`.
+- Concepts: `concepts/<slug>.md` — lowercase-kebab.
+- Decisions: `decisions/adr-NNNN-<slug>.md`.
+- Runbooks: `runbooks/runbook-<slug>.md`.
+- Sources: `sources/<category>/YYYY-MM-DD-<slug>.md`.
+- Synthesis: `synthesis/YYYY-MM-DD-<slug>.md`.
+
+## Non-goals
+
+- The wiki **is not** a task tracker — tasks live in the project's issue tracker / GitHub Project.
+- The wiki **does not** replace formal shared contracts.
+- The wiki **does not** replace user-facing product documentation.
+- The wiki **does not** replace per-repo implementation docs.
+
+The wiki is where **evolving synthesis** lives — the layer that used to die in chat history.

--- a/roles/llm_wiki/templates/INDEX.md.j2
+++ b/roles/llm_wiki/templates/INDEX.md.j2
@@ -1,0 +1,27 @@
+# {{ wiki_project_name }} Wiki Index
+
+Catalog of every page in the living zone (`sources/`, `entities/`, `concepts/`, `decisions/`, `runbooks/`, `synthesis/`). Maintained by the `wiki-keeper` subagent on every ingest and lint pass. See [CLAUDE.md](CLAUDE.md) for the schema.
+
+## Entities
+
+_(empty — populate via `/wiki-ingest` or by copying [templates/entity-template.md](templates/entity-template.md))_
+
+## Concepts
+
+_(empty — populate via `/wiki-ingest` or by copying [templates/concept-template.md](templates/concept-template.md))_
+
+## Decisions
+
+_(empty — copy [templates/decision-template.md](templates/decision-template.md) for the first ADR)_
+
+## Runbooks
+
+_(empty — copy [templates/runbook-template.md](templates/runbook-template.md) for your first runbook)_
+
+## Sources
+
+_(empty — first `/wiki-ingest` will populate)_
+
+## Synthesis
+
+_(empty — first `/wiki-query` with file-back will land here)_

--- a/roles/llm_wiki/templates/LOG.md.j2
+++ b/roles/llm_wiki/templates/LOG.md.j2
@@ -1,0 +1,24 @@
+# {{ wiki_project_name }} Wiki Log
+
+Chronological, append-only. Every ingest, query (with file-back), lint pass, and bulk operation gets one entry.
+
+Entry format:
+
+```
+## [YYYY-MM-DD] <op> | <label>
+```
+
+`<op>` is one of `ingest`, `query`, `filed-back`, `lint`, `scaffold`, `migrate`. Parse with:
+
+```bash
+grep "^## \[" {{ wiki_dir }}/LOG.md | tail -5
+grep "^## \[" {{ wiki_dir }}/LOG.md | grep lint
+```
+
+Entries are short — 1–3 lines of body. Detailed diffs live in git history.
+
+---
+
+## [{{ ansible_date_time.date }}] scaffold | initial wiki structure
+
+Bootstrap via `roles/llm_wiki/tasks/scaffold.yml`. Living-zone directories and schema/INDEX/LOG in place. Templates dropped under `{{ wiki_dir }}/templates/`. No pages seeded — first real content lands via `/wiki-ingest`.

--- a/roles/llm_wiki/templates/README-sources.md.j2
+++ b/roles/llm_wiki/templates/README-sources.md.j2
@@ -1,0 +1,24 @@
+---
+name: Sources
+type: source
+status: current
+created: {{ ansible_date_time.date }}
+updated: {{ ansible_date_time.date }}
+---
+
+# Sources
+
+Raw ingested material. **Immutable** once dropped — wiki-keeper reads but never rewrites.
+
+## Categories
+
+- `clippings/` — web articles, blog posts, docs. Use Obsidian Web Clipper.
+- `transcripts/` — meeting notes, customer-call transcripts, podcast transcripts.
+- `papers/` — PDFs, research, vendor whitepapers.
+- `assets/` — binary files, images, PDFs referenced by other sources.
+
+## Ingest
+
+Drop material and run `/wiki-ingest sources/<category>/<file>` (or `/wiki-ingest <url>` to fetch + file in one step). The wiki-keeper reads the source, summarises, and updates entity/concept pages.
+
+See [../CLAUDE.md](../CLAUDE.md) for the schema.

--- a/roles/llm_wiki/templates/README-synthesis.md.j2
+++ b/roles/llm_wiki/templates/README-synthesis.md.j2
@@ -1,0 +1,15 @@
+---
+name: Synthesis
+type: synthesis
+status: current
+created: {{ ansible_date_time.date }}
+updated: {{ ansible_date_time.date }}
+---
+
+# Synthesis
+
+Filed-back results of `/wiki-query`. Whenever a query produces a non-trivial answer worth persisting, the wiki-keeper offers to file it here so synthesis compounds instead of dying in chat history.
+
+Naming: `YYYY-MM-DD-<slug>.md`. Each page links back to and forward from the entities/concepts it drew from (`related:` frontmatter).
+
+See [../CLAUDE.md](../CLAUDE.md) for the schema.

--- a/roles/llm_wiki/templates/concept-template.md.j2
+++ b/roles/llm_wiki/templates/concept-template.md.j2
@@ -1,0 +1,33 @@
+---
+name: <Concept Name>
+type: concept
+tags: [<relevant-tags>]
+sources: []
+related: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: stub
+---
+
+# <Concept Name>
+
+<One-paragraph description: what this concept is, what problem it solves, when it applies.>
+
+## Why
+
+<Motivation. Why this concept exists rather than the obvious alternative.>
+
+## Rules / Principles
+
+- <rule 1>
+- <rule 2>
+- <rule 3>
+
+## Examples
+
+- <where it's applied in the codebase or docs>
+
+## Related
+
+- [[concepts/related-concept]]
+- [[entities/entity-where-applied]]

--- a/roles/llm_wiki/templates/decision-template.md.j2
+++ b/roles/llm_wiki/templates/decision-template.md.j2
@@ -1,0 +1,35 @@
+---
+name: ADR-NNNN <Decision Title>
+type: decision
+tags: [adr, <area>]
+sources: []
+related: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: current
+---
+
+# ADR-NNNN — <Decision Title>
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Superseded by [[decisions/adr-NNNN]]
+**Supersedes:** —
+
+## Context
+
+<What problem prompted this decision? What constraints applied? What was the state before?>
+
+## Decision
+
+<What was decided. Be specific.>
+
+## Consequences
+
+- **Positive:** <what this unblocks or improves>
+- **Negative / cost:** <what this complicates or gives up>
+- **Follow-ups:** <if anything must change downstream>
+
+## Alternatives considered
+
+- **<Option A>** — <why rejected>
+- **<Option B>** — <why rejected>

--- a/roles/llm_wiki/templates/entity-template.md.j2
+++ b/roles/llm_wiki/templates/entity-template.md.j2
@@ -1,0 +1,25 @@
+---
+name: <Entity Name>
+type: entity
+tags: [<kind>, <relevant-tags>]
+sources: []
+related: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: stub
+---
+
+# <Entity Name>
+
+<One-paragraph description: what this entity is, why it matters to the project.>
+
+## What we know
+
+- <fact 1> — [[source]]
+- <fact 2>
+- <fact 3>
+
+## Related
+
+- [[entities/related-entity-1]]
+- [[concepts/related-concept]]

--- a/roles/llm_wiki/templates/runbook-template.md.j2
+++ b/roles/llm_wiki/templates/runbook-template.md.j2
@@ -1,0 +1,42 @@
+---
+name: Runbook — <Topic>
+type: runbook
+tags: [<area>, runbook]
+sources: []
+related: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: stub
+---
+
+# Runbook — <Topic>
+
+<One-sentence: what this runbook helps you do, and when you'd reach for it.>
+
+## Prerequisites
+
+- <tool X installed>
+- <env var Y set>
+- <access to Z>
+
+## Steps
+
+```bash
+# 1. What to do
+command-here
+
+# 2. Next step
+command-here
+
+# 3. Verify
+expected-output-or-check
+```
+
+## Common failures
+
+- **<Failure mode>** — <what it looks like, how to recover>
+
+## Related
+
+- [[concepts/related-concept]]
+- [[runbooks/related-runbook]]

--- a/roles/llm_wiki/templates/source-clipping-template.md.j2
+++ b/roles/llm_wiki/templates/source-clipping-template.md.j2
@@ -1,0 +1,41 @@
+---
+name: <Source Title>
+type: source
+tags: [<topic>]
+sources: []
+related: []
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+status: current
+url: <original URL if web source>
+author: <original author>
+---
+
+# <Source Title>
+
+**Source:** <URL or file reference>
+**Date:** <publication date>
+**Author:** <original author>
+
+## Abstract
+
+<One paragraph: what this source says, the core claim or finding.>
+
+## Key takeaways
+
+- <3–5 bullets of the most durable facts or insights>
+
+## Full notes
+
+<Optional: structured notes from the source. Keep it short; the full text
+lives in the original file referenced above.>
+
+## How this updates the wiki
+
+- `[[entities/X]]` — <what changed>
+- `[[concepts/Y]]` — <what changed>
+
+## Related
+
+- [[entities/related]]
+- [[concepts/related]]

--- a/scaffold-wiki.yml
+++ b/scaffold-wiki.yml
@@ -1,0 +1,25 @@
+---
+# Scaffold the LLM-wiki structure into a target repo.
+#
+# Usage:
+#   ansible-playbook scaffold-wiki.yml \
+#     -e "wiki_target=/abs/path/to/repo"
+#
+# Optional overrides:
+#   -e "wiki_dir=docs"            # default — the subdir inside wiki_target
+#   -e "wiki_project_name=foo"    # default — derived from wiki_target basename
+#
+# Idempotent: never overwrites existing CLAUDE.md / INDEX.md / LOG.md /
+# READMEs / templates. Re-running only fills in missing files.
+
+- name: Scaffold LLM wiki
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  vars:
+    scaffold_wiki: true
+    install_qmd: false       # assume already installed via dev.yml
+    install_marp: false
+    install_pandoc: false
+  roles:
+    - role: llm_wiki


### PR DESCRIPTION
## Summary
Codify the LLM-wiki pattern as reusable Ansible provisioning so any project can scaffold the same wiki with one role invocation. Companion to SA-071 rollout in smart-agents-hub.

Pattern reference: https://gist.github.com/prashantsolanki3/baf5332058a11527489d96fca3ac93c0

## Changes (per-concern commits)
1. `feat(claude_code): add wiki-keeper agent + /wiki-* commands + wiki-maintenance skill` — user-level Claude assets
2. `feat(claude_code): register qmd MCP server` — `files/mcp/qmd.json` auto-merges into `~/.claude.json`
3. `feat(llm_wiki): new Ansible role with qmd installer and wiki scaffolder` — `roles/llm_wiki/` + `scaffold-wiki.yml`
4. `chore(dev.yml): include llm_wiki role + add @tobilu/qmd to claude_npm_packages` — wiring

## qmd details
- npm package: `@tobilu/qmd` (unscoped `qmd` on npmjs is an abandoned 2016 stub)
- binary: `qmd` on PATH after global install
- MCP command: `qmd mcp` (stdio)
- One-time per project: `qmd collection add docs/ && qmd embed`

## Scaffold usage
```
ansible-playbook scaffold-wiki.yml -e "wiki_target=/abs/path/to/repo"
```
Creates `docs/{CLAUDE,INDEX,LOG}.md` + `docs/{sources,entities,concepts,decisions,runbooks,synthesis,templates}/` with READMEs and page templates. Idempotent — never overwrites existing files.

## Test plan
- [ ] `ansible-playbook dev.yml --syntax-check` passes ✓ (verified locally)
- [ ] `ansible-playbook scaffold-wiki.yml --syntax-check` passes ✓ (verified locally)
- [ ] Scratch scaffold: `ansible-playbook scaffold-wiki.yml -e wiki_target=/tmp/wiki-smoketest` produces the expected tree
- [ ] After merge + `ansible-playbook dev.yml`: `which qmd` returns a path, `cat ~/.claude.json | jq .mcpServers.qmd` shows the MCP, `~/.claude/agents/wiki-keeper.md` and `~/.claude/commands/wiki-*.md` are symlinked
- [ ] Copilot review resolved
- [ ] `pr-review-toolkit:code-reviewer` clean

## Outside SmartAgents Project
`dots` is outside the SmartAgents repo governance set per smart-agents-hub `AI_INSTRUCTIONS.md:5-8`. This PR is not added to Project 2; it's cross-linked from hub umbrella #121.

## Linked
- Hub umbrella: prashantsolanki3/smart-agents-hub#121
- Hub implementation PR: prashantsolanki3/smart-agents-hub#123
- Cross-repo PRs (Project 2): backend #180, website #57, bc-extension #90, ai-infra #181