### PR TITLE
feat(claude_code): align claudeclaw env-var names with upstream #128

### DIFF
--- a/docs/TOKENS.md
+++ b/docs/TOKENS.md
@@ -14,8 +14,9 @@ Every credential the dots-managed Claude Code setup may consume. Set the ones yo
 |---|---|---|---|
 | `GH_TOKEN` / `GITHUB_TOKEN` | `github` | yes (if used) | Personal access token. `repo` scope for private repos. The `gh` CLI also picks this up. |
 | `TFE_TOKEN` | `terraform` | optional | HCP Terraform / TFE API token — only needed for private registries and `create_run` / workspace mutations. Public registry browsing works without it. |
-| `TELEGRAM_BOT_TOKEN` | `telegram`, `claudeclaw` | yes (if used) | Bot token from [@BotFather](https://t.me/botfather). Same token shared between the `telegram` plugin and `claudeclaw`'s telegram channel. |
-| `DISCORD_BOT_TOKEN` | `claudeclaw` | optional | Only required if you enable the Discord channel in claudeclaw. |
+| `TELEGRAM_BOT_TOKEN` | `telegram` | yes (if used) | Bot token from [@BotFather](https://t.me/botfather). Read by the official `telegram` MCP server. |
+| `TELEGRAM_TOKEN` | `claudeclaw` | yes (if used) | Same value as `TELEGRAM_BOT_TOKEN` — claudeclaw uses a different env var name (upstream PR [#128](https://github.com/moazbuilds/claudeclaw/pull/128)). Set both if you use both. |
+| `DISCORD_TOKEN` | `claudeclaw` | optional | Bot token from [discord.com/developers/applications](https://discord.com/developers/applications). Required only if you enable claudeclaw's Discord channel. |
 
 ## MCP-server auth (defined in `roles/claude_code/files/mcp/`)
 
@@ -43,6 +44,8 @@ export GH_TOKEN="ghp_..."
 export SONARQUBE_TOKEN="..."
 export SONARQUBE_ORGANIZATION="my-org"
 export TELEGRAM_BOT_TOKEN="..."
+export TELEGRAM_TOKEN="$TELEGRAM_BOT_TOKEN"   # claudeclaw reads this name
+export DISCORD_TOKEN="..."
 ```
 
 The `claude plugin install` and MCP `${VAR}` substitution both read from the live shell environment.
@@ -60,7 +63,8 @@ services:
       GH_TOKEN:          ${GH_TOKEN:-}
       TFE_TOKEN:         ${TFE_TOKEN:-}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
-      DISCORD_BOT_TOKEN: ${DISCORD_BOT_TOKEN:-}
+      TELEGRAM_TOKEN:    ${TELEGRAM_TOKEN:-${TELEGRAM_BOT_TOKEN:-}}
+      DISCORD_TOKEN:     ${DISCORD_TOKEN:-}
       SONARQUBE_TOKEN:   ${SONARQUBE_TOKEN:-}
       SONARQUBE_ORGANIZATION: ${SONARQUBE_ORGANIZATION:-}
 ```

--- a/roles/claude_code/files/claudeclaw/env.example
+++ b/roles/claude_code/files/claudeclaw/env.example
@@ -4,9 +4,12 @@
 #   you use. Anything left commented stays unset.
 # ▸ The `claudeclaw-start` wrapper (from roles/claude_code) sources this
 #   file before launching the daemon, so these exports become env vars
-#   in the daemon process. ClaudeClaw then substitutes $VAR references
-#   in settings.json at load time (requires upstream env-var substitution
-#   support — https://github.com/moazbuilds/claudeclaw/pull/103).
+#   in the daemon process. ClaudeClaw reads `TELEGRAM_TOKEN` and
+#   `DISCORD_TOKEN` directly from its env at load time and uses them in
+#   place of the corresponding fields in settings.json — see upstream
+#   https://github.com/moazbuilds/claudeclaw/pull/128 (merged 2026-04-26).
+#   Other providers (`ANTHROPIC_API_KEY`, `GLM_API_KEY`) are still consumed
+#   from the env directly by the spawned `claude` CLI.
 #
 # ▸ NEVER commit this file. It lives in ~/.config/claudeclaw/ and is
 #   gitignored by every project that uses ClaudeClaw. Dots ships only
@@ -30,8 +33,15 @@
 #export GLM_API_KEY=
 
 # ── Telegram bot — get token from @BotFather ─────────────────────────────────
-#export TELEGRAM_BOT_TOKEN=
+# claudeclaw reads TELEGRAM_TOKEN; the official `telegram` plugin (a separate
+# MCP server) reads TELEGRAM_BOT_TOKEN. Set both to the same value if you want
+# Telegram to work in both surfaces.
+#export TELEGRAM_TOKEN=
+#export TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"
 
 # ── Discord bot — https://discord.com/developers/applications ────────────────
-# Enable "Message Content Intent" under Privileged Gateway Intents.
-#export DISCORD_BOT_TOKEN=
+# Enable "Message Content Intent" under Privileged Gateway Intents. Read by
+# claudeclaw as `process.env.DISCORD_TOKEN`; overrides discord.token in
+# settings.json when set. dots ships no separate discord plugin — this is the
+# only var needed for Discord.
+#export DISCORD_TOKEN=

--- a/roles/claude_code/files/scripts/claudeclaw-start.sh
+++ b/roles/claude_code/files/scripts/claudeclaw-start.sh
@@ -61,11 +61,12 @@ USER_SETTINGS_TEMPLATE="$USER_CLAUDECLAW_DIR/settings.template.json"
 PROJECT_SETTINGS=".claude/claudeclaw/settings.json"
 
 # Source user-level env file if present so exported secrets become env vars
-# in the daemon process. ClaudeClaw then substitutes $VAR references in
-# settings.json at load time (requires claudeclaw >= the env-substitution
-# PR: https://github.com/moazbuilds/claudeclaw/pull/103; on older claudeclaw
-# the placeholder strings pass through literally and the user sees the
-# warning in daemon.log — safe but non-functional until upgrade).
+# in the daemon process. ClaudeClaw reads TELEGRAM_TOKEN and DISCORD_TOKEN
+# directly from its environment and uses them in place of the corresponding
+# fields in settings.json — see upstream
+# https://github.com/moazbuilds/claudeclaw/pull/128 (merged 2026-04-26).
+# Other vars (ANTHROPIC_API_KEY, GLM_API_KEY) are forwarded by cleanSpawnEnv
+# in runner.ts to spawned `claude` CLI processes.
 if [ -r "$USER_ENV_FILE" ]; then
   set -a
   # shellcheck disable=SC1090

--- a/roles/claude_code/templates/claudeclaw-settings.json.j2
+++ b/roles/claude_code/templates/claudeclaw-settings.json.j2
@@ -2,9 +2,19 @@
 
 This template seeds per-project settings at `<project>/.claude/claudeclaw/settings.json`
 on first `claudeclaw-start` in a new directory. Non-secret defaults come from the
-Ansible vars below; secrets live in `~/.config/claudeclaw/env` and are resolved by
-ClaudeClaw at load time (requires the env-var-substitution feature — see
-https://github.com/moazbuilds/claudeclaw/pull/103).
+Ansible vars below.
+
+Bot tokens are sourced from `~/.config/claudeclaw/env` and override the
+`telegram.token` / `discord.token` fields at daemon load time. ClaudeClaw reads
+`process.env.TELEGRAM_TOKEN` and `process.env.DISCORD_TOKEN` directly — see upstream
+https://github.com/moazbuilds/claudeclaw/pull/128 (merged 2026-04-26). The token
+fields below stay empty so the env values win whether or not the user populates them.
+
+`api` / `fallback.api` also default to empty: when set, the daemon exports them as
+`ANTHROPIC_AUTH_TOKEN` to spawned `claude` CLIs, which bypasses the platform credential
+store. Most users want keychain-based OAuth — leave these empty and put
+`export ANTHROPIC_API_KEY=...` in `~/.config/claudeclaw/env` only if you specifically
+need a long-lived API key (headless VPS, etc.).
 
 Override any field per-host via group_vars / host_vars or `-e claudeclaw_<field>=...`:
 
@@ -25,11 +35,11 @@ Override any field per-host via group_vars / host_vars or `-e claudeclaw_<field>
 -#}
 {
   "model": "{{ claudeclaw_model | default('opus') }}",
-  "api": "$ANTHROPIC_API_KEY",
+  "api": "",
   "sessionTimeoutMs": {{ claudeclaw_session_timeout_ms | default(1200000) }},
   "fallback": {
     "model": "{{ claudeclaw_fallback_model | default('glm') }}",
-    "api": "$GLM_API_KEY"
+    "api": ""
   },
   "agentic": {
     "enabled": {{ claudeclaw_agentic_enabled | default(true) | tojson }},
@@ -55,11 +65,11 @@ Override any field per-host via group_vars / host_vars or `-e claudeclaw_<field>
     "prompt": {{ claudeclaw_heartbeat_prompt | default('') | tojson }}
   },
   "telegram": {
-    "token": "$TELEGRAM_BOT_TOKEN",
+    "token": "",
     "allowedUserIds": {{ claudeclaw_telegram_user_ids | default([]) | tojson }}
   },
   "discord": {
-    "token": "$DISCORD_BOT_TOKEN",
+    "token": "",
     "allowedUserIds": {{ claudeclaw_discord_user_ids | default([]) | tojson }},
     "listenChannels": {{ claudeclaw_discord_channels | default([]) | tojson }}
   },


### PR DESCRIPTION
## Summary

- Rename claudeclaw env vars to match merged upstream PR [#128](https://github.com/moazbuilds/claudeclaw/pull/128) — `TELEGRAM_TOKEN` / `DISCORD_TOKEN` (claudeclaw) instead of `TELEGRAM_BOT_TOKEN` / `DISCORD_BOT_TOKEN`.
- Drop non-functional `$VAR` placeholders from `claudeclaw-settings.json.j2`. Upstream did **not** adopt generic `$VAR` substitution; only the two bot-token fields and a couple of provider fields are env-aware, so empty defaults + env override is the correct shape.
- Also empty-out `api` / `fallback.api`. They were rendering literal `"$ANTHROPIC_API_KEY"`, which `runner.ts` was setting as `ANTHROPIC_AUTH_TOKEN` on spawned `claude` CLIs — breaking keychain fallback.
- Update `claudeclaw-start.sh` and `docs/TOKENS.md` comments to match the new mechanism.

## Why

The dots template was written assuming PR #103 (generic `$VAR` substitution) would land upstream. It was closed unmerged and replaced by [#128](https://github.com/moazbuilds/claudeclaw/pull/128), which only does direct env override on `process.env.TELEGRAM_TOKEN` and `process.env.DISCORD_TOKEN`. Without this fix, a fresh user setup ends up with literal `$DISCORD_BOT_TOKEN` strings flowing to Discord and the bot fails to connect with no obvious error in `daemon.log`.

Closes #33.

## Test plan

- [x] `make check` — only diff against the pre-existing on-disk template is the four `$VAR` → `""` swaps; no regressions in unrelated tasks.
- [ ] `make dev` on macOS — re-renders `~/.config/claudeclaw/settings.template.json` and `~/.config/claudeclaw/env.example` cleanly.
- [ ] Smoke test claudeclaw daemon end-to-end with a real Discord bot token in `~/.config/claudeclaw/env`. (Tracked in the `prashantsolanki3/yolo` setup that this PR unblocks.)

## Migration

No-op for users who haven't created `~/.config/claudeclaw/env` yet — only `env.example` ships from dots, never `env`. Existing users with a populated env file will need to either:
- rename `TELEGRAM_BOT_TOKEN` → `TELEGRAM_TOKEN` (and add `TELEGRAM_BOT_TOKEN="$TELEGRAM_TOKEN"` if they also use the official `telegram` plugin), and
- rename `DISCORD_BOT_TOKEN` → `DISCORD_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)